### PR TITLE
Specify route-recognizer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "FakeXMLHttpRequest": "~0.0.1",
-    "route-recognizer": "*"
+    "route-recognizer": "~0.1.1"
   },
   "devDependencies": {
     "jquery": "~2.1.0"


### PR DESCRIPTION
This prevents the Broccoli issue of picking the wrong route-recognizer.js file
