### PR TITLE
Add queryParams to request object

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -77,6 +77,7 @@ Pretender.prototype = {
     var match = matches ? matches[0] : null;
     if (match) {
       request.params = match.params;
+      request.queryParams = matches.queryParams;
     }
 
     return match;

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -28,3 +28,13 @@ test("params are passed", function(){
   $.ajax({url: '/some/path/1'});
   equal(params.id, 1);
 });
+
+test("queryParams are passed", function(){
+  var params;
+  pretender.get('/some/path', function(request){
+    params = request.queryParams
+  });
+
+  $.ajax({url: '/some/path?zulu=nation'});
+  equal(params.zulu, 'nation');
+});


### PR DESCRIPTION
This adds a `queryParams` to the request object that is passed to the handler function. This is useful if you want to use the URLs query string parameters inside your handler function.

USAGE / TEST:

```
test("queryParams are passed", function(){
  var params;
  pretender.get('/some/path', function(request){
    params = request.queryParams
  });

  $.ajax({url: '/some/path?zulu=nation'});
  equal(params.zulu, 'nation');
});

```
