### PR TITLE
add support for passing through unhandled requests to native XHR

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ var server = new Pretender(function(){
 
 ```
 
+## Using the Native XMLHttpRequest Object for Unhandled Routes
+
+By default, pretender will throw an error if it doesn't know how to handle a route.
+You can optionally have the browser handle these requests by specifying `passthroughUnhandledRequests = true`:
+
+```js
+var pretender = new Pretender(function(){
+  // routes go here
+});
+pretender.passthroughUnhandledRequests = true;
+$.ajax('/something/on/the/server')
+```
+
+This is useful when using asynchronous script loaders such as Require.js.
+
 ### Clean up
 When you're done mocking, be sure to call `shutdown()` to restore the native XMLHttpRequest object:
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pretender",
+  "devDependencies": {
+    "qunitjs": "^1.12.0",
+    "karma-qunit": "^0.1.1",
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.3"
+  }
+}

--- a/test/undefined_route_test.js
+++ b/test/undefined_route_test.js
@@ -27,3 +27,15 @@ test("errors by default", function(){
     pretender.unhandledRequest(verb, path);
   }, 'Pretender intercepted GET /foo/bar but no handler was defined for this type of request');
 });
+
+asyncTest("can pass through to the native XMLHTTPRequest object if passthroughUnhandledRequests", function(){
+  var verb = 'GET', path = '/foo/bar';
+  pretender.passthroughUnhandledRequests = true;
+  var request = new window.XMLHttpRequest();
+  request.onload = function(data){
+    start();
+    equal(this.status, 404);
+  };
+  request.open(verb, path, true);
+  request.send();
+});


### PR DESCRIPTION
Also adds a package.json to make it easier to run karma and contribute
to the project.

I needed this so that certain urls would just go to the native request object so I could load stuff using Require.js
