### PR TITLE
Add missing semicolon.

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -95,4 +95,4 @@ Pretender.prototype = {
   shutdown: function shutdown(){
     window.XMLHttpRequest = this._nativeXMLHttpRequest
   }
-}
+};


### PR DESCRIPTION
This missing semicolon causes problems during concat if the first char of the
next file is a paren.
