### PR TITLE
Setup to work with npm

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "./bower_components"
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,21 @@
 {
   "name": "pretender",
+  "main": "./pretender.js",
+  "scripts": {
+    "postinstall": "bower install",
+    "test": "./node_modules/karma/bin/karma start"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trek/pretender.git"
+  },
   "devDependencies": {
+    "bower": "^1.3.5",
     "karma": "^0.12.16",
-    "karma-qunit": "^0.1.1",
-    "karma": "^0.12.16",
-    "karma-chrome-launcher": "^0.1.3"
+    "karma-chrome-launcher": "^0.1.3",
+    "karma-qunit": "^0.1.1"
+  },
+  "dependencies": {
+    "route-recognizer": "^0.1.0"
   }
 }

--- a/pretender.js
+++ b/pretender.js
@@ -1,3 +1,6 @@
+var isNode = typeof process !== 'undefined' && process.toString() === '[object process]';
+var RouteRecognizer = isNode ? require('route-recognizer') : window.RouteRecognizer;
+var FakeXMLHttpRequest = isNode ? require('./bower_components/FakeXMLHttpRequest/fake_xml_http_request') : window.FakeXMLHttpRequest;
 var forEach = [].forEach;
 
 function Pretender(maps){
@@ -96,3 +99,7 @@ Pretender.prototype = {
     window.XMLHttpRequest = this._nativeXMLHttpRequest
   }
 };
+
+if (isNode) {
+  module.exports = Pretender;
+}


### PR DESCRIPTION
See #11. This still uses the bower stuff, which should be removed [once](https://github.com/trek/FakeXMLHttpRequest/pull/3) `FakeXMLHttpRequest` is published to npm.

Todo after adding above to npm:
- [ ] Add dep in package.json
- [ ] Fix require statement in pretender.js

I plan on updating these once it's in npm. But this can be merged as is.
