### PR TITLE
Added simple console.log logging to quickly identify unmocked requests

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -81,7 +81,11 @@ Pretender.prototype = {
     }
   },
   unhandledRequest: function(verb, path, request) {
-    throw new Error("Pretender intercepted "+verb+" "+path+" but no handler was defined for this type of request")
+    var message = "Pretender intercepted "+verb+" "+path+" but no handler was defined for this type of request";
+    if (console.log) {
+      console.log(message);
+    }
+    throw new Error(message);
   },
   _handlerFor: function(request){
     var registry = this.registry[request.method.toUpperCase()];


### PR DESCRIPTION
We needed simple logging to highlight when requests weren't mocked, and were silently getting swallowed by our app.  I've added a simple console.log to `unhandledRequest`.  Recent discussion on this topic at https://github.com/trek/pretender/issues/5.
