### PR TITLE
try-catch handler errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ var server = new Pretender(function(){
 
 ```
 
-###
-
 ### Tracking Requests
 Your pretender instance will track handlers and requests on a few array properties.
 All handlers are stored on `handlers` property and incoming requests will be tracked in one of
@@ -71,6 +69,42 @@ two properties: `handledRequests` and `unhandledRequests`. This is useful if you
 testing infrastructure on top of pretender and need to fail tests that have handlers without requests.
 
 Each handler keeps a count of the number of requests is successfuly served.
+
+### Hooks
+
+You can override specific hooks in pretender.
+
+```javascript
+var server = new Pretender(function(){
+  this.get('/api/songs', function(request){
+    throw new Error('something broke!');
+  });
+});
+
+// fires when a request is made
+// that does not match a route
+server.unhandledRequest = function(verb, path, request){
+  verb; // HTTP verb
+  path; // path requested
+  request; // xhr object
+
+  // default behavior
+  throw new Error("Pretender intercepted "+verb+" "+path+" but no handler was defined for this type of request")
+};
+
+// first when a request handler
+// throws an error
+server.erroredRequest = function(verb, path, request, error){
+  verb; // HTTP verb
+  path; // path requested
+  request; // xhr object
+  error; // error object
+
+  // default behavior
+  error.message = "Pretender intercepted "+verb+" "+path+" but encountered an error: " + error.message;
+  throw error;
+};
+```
 
 ### Clean up
 When you're done mocking, be sure to call `shutdown()` to restore the native XMLHttpRequest object:

--- a/pretender.js
+++ b/pretender.js
@@ -74,7 +74,11 @@ Pretender.prototype = {
     if (handler) {
       handler.handler.numberOfCalls++;
       this.handledRequests.push(request);
-      request.respond.apply(request, handler.handler(request));
+      try {
+        request.respond.apply(request, handler.handler(request));
+      } catch (error) {
+        this.erroredRequest(request.method.toUpperCase(), request.url, request, error);
+      }
     } else {
       this.unhandledRequests.push(request);
       this.unhandledRequest(request.method.toUpperCase(), request.url, request);
@@ -82,6 +86,10 @@ Pretender.prototype = {
   },
   unhandledRequest: function(verb, path, request) {
     throw new Error("Pretender intercepted "+verb+" "+path+" but no handler was defined for this type of request")
+  },
+  erroredRequest: function(verb, path, request, error){
+    error.message = "Pretender intercepted "+verb+" "+path+" but encountered an error: " + error.message;
+    throw error;
   },
   _handlerFor: function(request){
     var registry = this.registry[request.method.toUpperCase()];

--- a/test/error_handler_test.js
+++ b/test/error_handler_test.js
@@ -1,0 +1,23 @@
+var pretender;
+module("pretender errored requests", {
+  setup: function(){
+    pretender = new Pretender();
+  },
+  teardown: function(){
+    pretender && pretender.shutdown();
+    pretender = null;
+  }
+});
+
+test("errors are captured in route handlers", function(){
+  pretender.get('/some/path', function(){
+    throw new Error('something in this handler broke!');
+  });
+
+  pretender.erroredRequest = function(verb, path, request, error){
+    ok(error);
+  };
+
+  $.ajax({url: '/some/path'});
+});
+


### PR DESCRIPTION
When a router handler errors, pretender never responds. It would be useful to be able to customize this behavior so that I can provide better error messages to the developers working with my project.

This PR adds a hook for `erroredRequest` and documents both `unhandledRequest` and `erroredRequest`.
