### PR TITLE
Adds support for cross origin requests

### DIFF
--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -96,3 +96,19 @@ test("will use the latest defined handler", function(){
   $.ajax({url: '/some/path'});
   ok(latestHandlerWasCalled, 'calls the latest handler');
 });
+
+test("recognizes cross domain requests", function(){
+  var wasCalled;
+  var wasNotCalled = true;
+  pretender.get('http://some-other-domain.com/some/path', function() {
+    wasCalled = true;
+  });
+  pretender.get('/some/path', function() {
+    wasNotCalled = false;
+  });
+
+  $.ajax({url: 'http://some-other-domain.com/some/path'});
+
+  ok(wasCalled);
+  ok(wasNotCalled);
+});


### PR DESCRIPTION
This adds support for cross origin requests like discussed in trek/pretender#17. It keeps separate route recognizers per origin and verb.
