### PR TITLE
Include response text and status in handleRequest hook

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -77,16 +77,14 @@ Pretender.prototype = {
     if (handler) {
       handler.handler.numberOfCalls++;
       this.handledRequests.push(request);
-      this.handledRequest(verb, path, request);
-
 
       try {
         var statusHeadersAndBody = handler.handler(request),
             status = statusHeadersAndBody[0],
             headers = statusHeadersAndBody[1],
             body = this.prepareBody(statusHeadersAndBody[2]);
-
         request.respond(status, headers, body);
+        this.handledRequest(verb, path, request);
       } catch (error) {
         this.erroredRequest(verb, path, request, error);
       }

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -61,11 +61,20 @@ test("increments the handler's request count", function(){
   equal(handler.numberOfCalls, 1);
 });
 
-test("handledRequest is called", function(){
-  pretender.get('/some/path', function(){});
-  pretender.handledRequest = function(){
+asyncTest("handledRequest is called", function(){
+  var json = "{foo: 'bar'}";
+  pretender.get('/some/path', function(req){
+    return [200, {}, obj];
+  });
+  pretender.handledRequest = function(verb, path, request){
     ok(true, "handledRequest hook was called");
+    equal(verb, "GET");
+    equal(path, "/some/path");
+    equal(request.responseText, json);
+    equal(request.responseStatus, "200");
+    QUnit.start();
   };
+
   $.ajax({url: '/some/path'});
 });
 


### PR DESCRIPTION
I wanted to check the responses that were coming back from pretender. This PR moves the handleRequest hook to after when the response has been generated allowing you to access the response in the hook e.g.

```
server.handledRequest = function(verb, path, request) {
  console.log({
    verb: verb,
    path: path,
    responseText: request.responseText,
    responseStatus: request.responseStatus
  });
};
```
