### PR TITLE
Provided tests to show `queryParams` do not work with PUT/POST requests.

### DIFF
--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -29,13 +29,33 @@ test("params are passed", function(){
   equal(params.id, 1);
 });
 
-test("queryParams are passed", function(){
+test("queryParams are passed with GET", function(){
   var params;
   pretender.get('/some/path', function(request){
     params = request.queryParams;
   });
 
   $.ajax({url: '/some/path?zulu=nation'});
+  equal(params.zulu, 'nation');
+});
+
+test("queryParams are passed with POST", function(){
+  var params;
+  pretender.post('/some/path', function(request){
+    params = request.queryParams;
+  });
+
+  $.ajax({url: '/some/path', type: 'POST', data: { zulu: 'nation' }});
+  equal(params.zulu, 'nation');
+});
+
+test("queryParams are passed with PUT", function(){
+  var params;
+  pretender.put('/some/path', function(request){
+    params = request.queryParams;
+  });
+
+  $.ajax({url: '/some/path', type: 'PUT', data: { zulu: 'nation' }});
   equal(params.zulu, 'nation');
 });
 


### PR DESCRIPTION
I'm not sure what the best way to fix this is. It seems the code relies on the route recognizer to handle this. 

My use case is simply that I want to test my custom adapter and that means verifying the data passed to the  createRecord and updateRecord endpoints. 
