### PR TITLE
Enable pass-through routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ var server = new Pretender(function(){
 });
 ```
 
+### Pass-Through
+To set certain paths that should be ignored by the interceptor and made as real XHR requests, these
+can be enabled by specifying pass-through routes:
+
+```javascript
+var server = new Pretender(function(){
+  this.get('/photos/:id', this.passthrough);
+});
+```
+
 ## Hooks
 ### Handled Requests
 In addition to responding to the request, your server will call a `handledRequest` method with
@@ -142,6 +152,19 @@ server.unhandledRequest = function(verb, path, request) {
 }
 
 $.getJSON("/these/arent/the/droids");
+```
+
+### Pass-through Requests
+Requests set to be handled by pass-through will trigger the `passthroughRequest` hook:
+
+```javascript
+var server = new Pretender(function(){
+  this.get('/some/path', this.passthrough);
+});
+
+server.passthroughRequest = function(verb, path, request) {
+  console.log('request ' + path + ' sucessfully sent for passthrough');
+}
 ```
 
 

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -1,0 +1,29 @@
+var pretender;
+module("pretender invoking", {
+  setup: function(){
+    pretender = new Pretender();
+  },
+  teardown: function(){
+    pretender && pretender.shutdown();
+    pretender = null;
+  }
+});
+asyncTest("allows matched paths to be pass-through", function(){
+  pretender.get('/some/:route', pretender.passthrough);
+
+  var passthroughInvoked = false;
+  pretender.passthroughRequest = function(verb, path, request) {
+    passthroughInvoked = true;
+    equal(verb, 'GET');
+    equal(path, '/some/path');
+  };
+
+  $.ajax({
+    url: '/some/path',
+    error: function(xhr) {
+      equal(xhr.status, 404);
+      ok(passthroughInvoked);
+      start();
+    }
+  });
+});


### PR DESCRIPTION
This implements something like described in #34, and as suggested, will wrap the fake XHR ensuring properties and events are communicated from the real XHR.

Thanks to @johnmcdowall for the initial work on this.
