### PR TITLE
Set requestBody for passthrough requests

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -51,8 +51,8 @@ function interceptor(pretender) {
             'a pretender earlier than you intended to');
     }
 
+    FakeXMLHttpRequest.prototype.send.apply(this, arguments);
     if (!pretender.checkPassthrough(this)) {
-      FakeXMLHttpRequest.prototype.send.apply(this, arguments);
       pretender.handleRequest(this);
     }
     else {

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -9,19 +9,24 @@ module("pretender invoking", {
   }
 });
 asyncTest("allows matched paths to be pass-through", function(){
-  pretender.get('/some/:route', pretender.passthrough);
+  pretender.post('/some/:route', pretender.passthrough);
 
   var passthroughInvoked = false;
   pretender.passthroughRequest = function(verb, path, request) {
     passthroughInvoked = true;
-    equal(verb, 'GET');
+    equal(verb, 'POST');
     equal(path, '/some/path');
+    equal(request.requestBody, 'some=data');
   };
 
   $.ajax({
     url: '/some/path',
+    method: 'POST',
     headers: {
       'test-header': 'value'
+    },
+    data: {
+      'some': 'data'
     },
     error: function(xhr) {
       equal(xhr.status, 404);


### PR DESCRIPTION
Without this `requestBody` will always be `undefined` for pas through requests which is a problem when using Pretender passthrough to test that certain requests with certain data are made.
