### PR TITLE
Add jspm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,13 @@
   "dependencies": {
     "fake-xml-http-request": "^1.2.0",
     "route-recognizer": "^0.1.9"
+  },
+  "jspm": {
+    "shim": {
+      "pretender": {
+        "deps": ["route-recognizer", "fake-xml-http-request"],
+        "exports": "Pretender"
+      }
+    }
   }
 }


### PR DESCRIPTION
This shim is necessary to work for jspm because otherwise it runs as a CommonJS module, while failing the `isNode` check, resulting in the dependencies not being picked up.

An alternative approach would be to change the `isNode` function to accept the browserify process shim, perhaps by checking a standard property.

No pressure to take this either, we have an override that's making it work otherwise.