### PR TITLE
Remove setting of timeout on synchronous request obj

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -88,7 +88,6 @@ function interceptor(pretender) {
       };
     })(evts[i]);
     xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
-    xhr.timeout = fakeXHR.timeout;
     xhr.withCredentials = fakeXHR.withCredentials;
     for (var h in fakeXHR.requestHeaders) {
       xhr.setRequestHeader(h, fakeXHR.requestHeaders[h]);


### PR DESCRIPTION
This line caused an error like "Failed to set the timeout
property on XMLHttpRequest: Timeouts cannot be set for
synchronous requests made from a document."

I get this message in uptodate Chrome 41.0.2272.118 (64-bit)
and Firefox 37.0.1. My German FF prints the message in
German, so this must be a browser-side restriction.
