### PR TITLE
Fix wrong invocation of dispatchEvent method for passthrough requests.

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -81,7 +81,7 @@ function interceptor(pretender) {
           }
         }
         // fire fake events where applicable
-        fakeXHR.dispatchEvent(evt, e);
+        fakeXHR.dispatchEvent(e);
         if (fakeXHR['on' + evt]) {
           fakeXHR['on' + evt](e);
         }


### PR DESCRIPTION
This fixes a bug where event listeners added via addEventListener() to a passthrough request were not being called.