### PR TITLE
Support responseType for passthrough requests

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -95,7 +95,7 @@ function interceptor(pretender) {
     xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
     xhr.timeout = fakeXHR.timeout;
     xhr.withCredentials = fakeXHR.withCredentials;
-    xhr.responseType = fakeXHR.responseType;
+    xhr.responseType = fakeXHR.responseType || '';
     for (var h in fakeXHR.requestHeaders) {
       xhr.setRequestHeader(h, fakeXHR.requestHeaders[h]);
     }


### PR DESCRIPTION
Currently the responseType of the fake xhr is ignored, so any special responseType like "arraybuffer" does not work. This will fix it. Probably also https://github.com/trek/pretender/issues/72 if passthrough requests are involved.