### PR TITLE
Remove node

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,13 +1,17 @@
 {
   "predef": [
-    "self"
+    "self",
+    "require",
+    "module",
+    "define",
+    "process"
   ],
   "expr": true,
   "proto": true,
   "strict": true,
   "indent": 2,
   "camelcase": true,
-  "node": true,
+  "node": false,
   "browser": true,
   "boss": true,
   "curly": true,

--- a/pretender.js
+++ b/pretender.js
@@ -1,8 +1,12 @@
 (function(self) {
 'use strict';
-var isNode = typeof process !== 'undefined' && process.toString() === '[object process]';
-var RouteRecognizer = isNode ? require('route-recognizer') : window.RouteRecognizer;
-var FakeXMLHttpRequest = isNode ? require('fake-xml-http-request') : window.FakeXMLHttpRequest;
+
+var appearsBrowserified = typeof self !== 'undefined' &&
+                          typeof process !== 'undefined' &&
+                          Object.prototype.toString.call(process) === '[object Object]';
+
+var RouteRecognizer = appearsBrowserified ? require('route-recognizer') : self.RouteRecognizer;
+var FakeXMLHttpRequest = appearsBrowserified ? require('fake-xml-http-request') : self.FakeXMLHttpRequest;
 
 /**
  * parseURL - decompose a URL into its parts
@@ -91,11 +95,11 @@ function Pretender(/* routeMap1, routeMap2, ...*/) {
 
   // reference the native XMLHttpRequest object so
   // it can be restored later
-  this._nativeXMLHttpRequest = window.XMLHttpRequest;
+  this._nativeXMLHttpRequest = self.XMLHttpRequest;
 
   // capture xhr requests, channeling them into
   // the route map.
-  window.XMLHttpRequest = interceptor(this);
+  self.XMLHttpRequest = interceptor(this);
 
   // 'start' the server
   this.running = true;
@@ -368,10 +372,12 @@ Pretender.parseURL = parseURL;
 Pretender.Hosts = Hosts;
 Pretender.Registry = Registry;
 
-if (isNode) {
+if (typeof module === 'object') {
   module.exports = Pretender;
-} else {
-  self.Pretender = Pretender;
+} else if (typeof define !== 'undefined') {
+  define('pretender', [], function() {
+    return Pretender;
+  });
 }
-
+self.Pretender = Pretender;
 }(self));


### PR DESCRIPTION
this depends on: https://github.com/pretenderjs/pretender/pull/95

relevant commit: https://github.com/pretenderjs/pretender/commit/71dbac0a240fc202fb90b95d5b8516eb2f55f2eb

Why?:

* the current code does not support node, it uses window/self all over the place
* the current node detection breaks in NW.js environments
* the code isn't tested on node
* node doesn't have `global.XMLHTTPRequest` 
  * in theory, we attempt to patch https://github.com/driverdan/node-XMLHttpRequest, but do to how NPM dedupes stuff, this is likely fraught with peril.

@trek this may be controversial so I would like your +1