### PR TITLE
Fix jQuery 1.x never calling complete

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -7,6 +7,7 @@ var appearsBrowserified = typeof self !== 'undefined' &&
 
 var RouteRecognizer = appearsBrowserified ? require('route-recognizer') : self.RouteRecognizer;
 var FakeXMLHttpRequest = appearsBrowserified ? require('fake-xml-http-request') : self.FakeXMLHttpRequest;
+var jQuery = appearsBrowserified ? require('jquery') : self.jQuery;
 
 /**
  * parseURL - decompose a URL into its parts
@@ -110,6 +111,11 @@ function Pretender(/* routeMap1, routeMap2, ...*/) {
   }
 }
 
+function onLoadSupported() {
+  var majorVersion = ~~jQuery.fn.jquery.split('.')[0];
+  return majorVersion > 1;
+}
+
 function interceptor(pretender) {
   function FakeRequest() {
     // super()
@@ -140,7 +146,8 @@ function interceptor(pretender) {
     var xhr = fakeXHR._passthroughRequest = new pretender._nativeXMLHttpRequest();
 
     // Use onload instead of onreadystatechange if the browser supports it
-    if ('onload' in xhr) {
+    // jQuery 1.x only supports onreadystatechange
+    if ('onload' in xhr && onLoadSupported()) {
       evts.push('load');
     } else {
       evts.push('readystatechange');


### PR DESCRIPTION
Fixes https://github.com/pretenderjs/pretender/issues/85.

Tried to find a way to check for this case without referring to jQuery directly but it can't really be avoided.

Tests should ideally be ran against jQuery 1.x and 2.x but that is going to require some project restructuring.

Two of the async/synchronous tests fail with jQuery 1.x for some reason. It seems like a difference in the way 1.x interacts with XMLHttpRequest. I think it may need to be addressed upstream (in FakeXMLHttpRequest). Any ideas @trek or @mike-north?