### PR TITLE
use better error message when not returning in handler

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -218,6 +218,10 @@ function scheduleProgressEvent(request, startTime, totalTime) {
   }, 50);
 }
 
+function isArray(array) {
+  return Object.prototype.toString.call(array) === '[object Array]';
+}
+
 var PASSTHROUGH = {};
 
 Pretender.prototype = {
@@ -277,8 +281,13 @@ Pretender.prototype = {
       this.handledRequests.push(request);
 
       try {
-        var statusHeadersAndBody = handler.handler(request),
-            status = statusHeadersAndBody[0],
+        var statusHeadersAndBody = handler.handler(request);
+        if (!isArray(statusHeadersAndBody)) {
+          var note = 'Remember to `return [status, headers, body];` in your route handler.';
+          throw new Error('Nothing returned by handler for ' + path + '. ' + note);
+        }
+
+        var status = statusHeadersAndBody[0],
             headers = this.prepareHeaders(statusHeadersAndBody[1]),
             body = this.prepareBody(statusHeadersAndBody[2]),
             pretender = this;

--- a/test/undefined_response_test.js
+++ b/test/undefined_response_test.js
@@ -1,0 +1,27 @@
+var pretender;
+module('pretender undefined response', {
+  setup: function() {
+    pretender = new Pretender();
+  },
+  teardown: function() {
+    if (pretender) {
+      pretender.shutdown();
+    }
+    pretender = null;
+  }
+});
+
+test('calls erroredRequest', function(assert) {
+  pretender.get('/some/path', function() {
+    // return nothing
+  });
+
+  pretender.erroredRequest = function(verb, path, request, error) {
+    var message = 'Nothing returned by handler for ' + path + '. ' +
+      'Remember to `return [status, headers, body];` in your route handler.';
+    assert.equal(error.message, message);
+  };
+
+  $.ajax({url: '/some/path'});
+});
+


### PR DESCRIPTION
When you don't return the proper array format in your handlers, you'll get an error like:

> Pretender intercepted GET /some/path but encountered an error: Cannot read property '0' of undefined"

This PR improves that situation by throwing an error that says something like:

> Nothing returned by handler for /some/path. Remember to `return [status, headers, body];` in your route handler.

---

Addresses https://github.com/pretenderjs/pretender/issues/106