### PR TITLE
Remove Timeout, WithCredential and onProgress for synchronous XHR

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -134,7 +134,7 @@ function interceptor(pretender) {
   };
 
   // passthrough handling
-  var evts = ['error', 'timeout', 'progress', 'abort'];
+  var evts = ['error', 'timeout', 'abort'];
   var lifecycleProps = ['readyState', 'responseText', 'responseXML', 'status', 'statusText'];
   function createPassthrough(fakeXHR) {
     var xhr = fakeXHR._passthroughRequest = new pretender._nativeXMLHttpRequest();
@@ -144,6 +144,11 @@ function interceptor(pretender) {
       evts.push('load');
     } else {
       evts.push('readystatechange');
+    }
+
+    // add progress event for async calls
+    if (fakeXHR.async) {
+      evts.push('progress');
     }
 
     /*jshint -W083 */
@@ -170,8 +175,10 @@ function interceptor(pretender) {
     /*jshint +W083 */
     // jscs:enable requireCurlyBraces
     xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
-    xhr.timeout = fakeXHR.timeout;
-    xhr.withCredentials = fakeXHR.withCredentials;
+    if (fakeXHR.async) {
+      xhr.timeout = fakeXHR.timeout;
+      xhr.withCredentials = fakeXHR.withCredentials;
+    }
     for (var h in fakeXHR.requestHeaders) {
       xhr.setRequestHeader(h, fakeXHR.requestHeaders[h]);
     }


### PR DESCRIPTION
I need pretender to send synchronous XHR on passthrough, and currently, pretender will add Timeout, WithCredential and onProgress event to the synchronous XHR.

These should be removed for synchronous XHR:
http://stackoverflow.com/questions/12472395/withcredentials-property-is-not-supported-in-firefox
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
Use of XMLHttpRequest's withCredentials attribute is no longer supported in the synchronous mode in window context.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
You may not use a timeout for synchronous requests with an owning window.

https://bugs.webkit.org/show_bug.cgi?id=40996
Progress event should not be fired during synchronous XMLHttpRequest

On chrome, the rules below are not enforced, but it is in Firefox, so request will fail on firefox.