### PR TITLE
Decode URI for phantomjs

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -365,7 +365,11 @@ Pretender.prototype = {
   },
   _handlerFor: function(verb, url, request) {
     var registry = this.hosts.forURL(url)[verb];
-    var matches = registry.recognize(parseURL(url).fullpath);
+    var fullpath = parseURL(url).fullpath;
+    var matches = registry.recognize(fullpath);
+    if (matches === undefined) {
+      registry.recognize(decodeURIComponent(fullpath));
+    }
 
     var match = matches ? matches[0] : null;
     if (match) {

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -457,3 +457,16 @@ test('resolves cross-origin requests', function() {
   ok(wasCalled);
 
 });
+
+test('url with encoded characters', function() {
+  var wasCalled;
+  var encodedChar = 'encoded:char';
+  var urlpath = '/some/path/' + encodeURIComponent(encodedChar);
+
+  pretender.get(urlpath, function() {
+    wasCalled = true;
+  });
+
+  $.ajax({url: urlpath});
+  ok(wasCalled);
+});


### PR DESCRIPTION
Due to the v 0.8 changes to add the hosts, parseURL(url).fullpath is returning different values for phantomjs and Chrome/Firefox when we have special characters are involved in the URL. 

Example:

For url = '/some/path/' + encodeURIComponent('encoded:char'), we get.. '/some/path/encoded%3Achar'
Hence we call: pretender.get( '/some/path/encoded%3Achar', somejson );

When pretender intercepts and handlesRequest
In Phantomjs, parseURL(url).fullpath = /some/path/encoded%3Achar
while in Chrome, parseURL(url).fullpath = /some/path/encoded%253Achar  (double encoding)

Also, within routeRecognizer, the states are stored differently.
In Phantomjs, registry.recognize matches for /some/path/encoded:char in the state.
while in Chrome, registry.recognize matches for /some/path/encoded%3Achar in the state.