### PR TITLE
test that `on`- and `addEventListener` callbacks fire on passthrough

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -165,7 +165,7 @@ function interceptor(pretender) {
             }
           }
           // fire fake events where applicable
-          fakeXHR.dispatchEvent(evt, e);
+          fakeXHR.dispatchEvent(e);
           if (fakeXHR['on' + evt]) {
             fakeXHR['on' + evt](e);
           }


### PR DESCRIPTION
This PR changes:
  * restores the native window.XMLHttpRequest correctly in "passthrough" tests
  * fixes an incorrect call to FakeXHR#dispatch that caused event listeners added using `addEventListener` from firing on passed-through requests

In the passthrough tests, there are a few places where `pretender._nativeXMLHttpRequest` is changed in order to facilitate testing, but Pretender [sets the window's `XMLHttpRequest` to `this._nativeXMLHttpRequest`](https://github.com/pretenderjs/pretender/blob/053b865064cf09dc6a07800b7a5039880381a8df/pretender.js#L379) in `#shutdown`. This resulted in `window.XMLHttpRequest` getting incorrectly permanently changed to the stub `tesXHR` method when those tests call `pretender.shutdown` in `teardown`.

FakeXMLHttpRequest's [`dispatchEvent` method](https://github.com/pretenderjs/FakeXMLHttpRequest/blob/f48f3b8087ecb6df2ffd16ef31bd0e1bed7989f7/src/fake-xml-http-request.js#L169)
must be called with the event (which must have a `type` key) instead of
`(eventName, event)`. When called with the `eventName` string as the first argument, the fake XHR never locates the `addEventListener`-added listeners and so never calls them. This PR fixes the call to `dispatchEvent` to have the correct parameter and adds tests that callbacks added using both methods will be called.