### PR TITLE
Update fake-xml-http-request bower and npm dep to 1.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "./pretender.js"
   ],
   "dependencies": {
-    "FakeXMLHttpRequest": "~1.2.0",
+    "FakeXMLHttpRequest": "~1.2.1",
     "route-recognizer": "~0.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "qunitjs": "^1.18.0"
   },
   "dependencies": {
-    "fake-xml-http-request": "^1.2.0",
+    "fake-xml-http-request": "^1.2.1",
     "route-recognizer": "^0.1.9"
   },
   "jspm": {


### PR DESCRIPTION
This brings in a fix that prevents changing an explicitly-set 'Content-Type' request header
(https://github.com/pretenderjs/FakeXMLHttpRequest/pull/17).