### PR TITLE
Fix repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/trek/pretender.git"
+    "url": "https://github.com/pretenderjs/pretender.git"
   },
   "devDependencies": {
     "bower": "^1.3.5",


### PR DESCRIPTION
Now pretender is organized by [pretenderjs](https://github.com/pretenderjs).