### PR TITLE
use sinon.fakeTimers to reduce test flakiness

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['qunit'],
+    frameworks: ['qunit', 'sinon'],
 
 
     // list of files / patterns to load in the browser

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "karma-coverage": "^0.5.0",
     "karma-phantomjs-launcher": "^0.2.0",
     "karma-qunit": "^0.1.3",
+    "karma-sinon": "^1.0.4",
     "phantomjs": "^1.9.17",
-    "qunitjs": "^1.18.0"
+    "qunitjs": "^1.18.0",
+    "sinon": "^1.17.2"
   },
   "dependencies": {
     "fake-xml-http-request": "^1.2.1",

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -348,8 +348,8 @@ test('async requests with `onprogress` upload events in the upload ' +
 });
 
 test('`onprogress` upload events don\'t keep firing once the request has ended', function(assert) {
-  var done = assert.async();
   var progressEventCount = 0;
+  var clock = sinon.useFakeTimers();
   pretender.post('/uploads', function(request) {
     return [200, {}, ''];
   }, 210);
@@ -360,10 +360,9 @@ test('`onprogress` upload events don\'t keep firing once the request has ended',
     progressEventCount++;
   };
   xhr.send('some data');
-  setTimeout(function() {
-    equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
-    done();
-  }, 510);
+  clock.tick(510);
+  equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
+  clock.restore();
 });
 
 test('no progress upload events are fired after the request is aborted', function(assert) {
@@ -405,7 +404,7 @@ test('async requests with `onprogress` events trigger a progress event each 50ms
 });
 
 test('`onprogress` download events don\'t keep firing once the request has ended', function(assert) {
-  var done = assert.async();
+  var clock = sinon.useFakeTimers();
   var progressEventCount = 0;
   pretender.get('/downloads', function(request) {
     return [200, {}, ''];
@@ -417,10 +416,9 @@ test('`onprogress` download events don\'t keep firing once the request has ended
     progressEventCount++;
   };
   xhr.send('some data');
-  setTimeout(function() {
-    equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
-    done();
-  }, 510);
+  clock.tick(510);
+  equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
+  clock.restore();
 });
 
 test('no progress download events are fired after the request is aborted', function(assert) {


### PR DESCRIPTION
These tests pass intermittently due to the unreliability of using
setTimeout in a scheduled fashion. Introducing fakeTimers allow us to
more reliably manipulate in-browser timing APIs.
