### PR TITLE
Fix readystatechange

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "route-recognizer": "~0.1.1"
   },
   "devDependencies": {
-    "jquery": "~2.1.0"
+    "jquery": "~2.1.0",
+    "jquery-1": "https://code.jquery.com/jquery-1.11.3.min.js"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function(config) {
     files: [
       'bower_components/FakeXMLHttpRequest/fake_xml_http_request.js',
       'bower_components/route-recognizer/dist/route-recognizer.js',
+      'bower_components/jquery-1/index.js',
       'bower_components/jquery/dist/jquery.js',
       'pretender.js',
       'test/**/*.js'

--- a/pretender.js
+++ b/pretender.js
@@ -182,8 +182,6 @@ function interceptor(pretender) {
       };
     }
 
-    xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
-
     // set the on- handler on the native xhr's `upload` property for
     // the given eventType
     function createUploadHandler(eventType) {
@@ -193,6 +191,8 @@ function interceptor(pretender) {
         };
       }
     }
+
+    xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
 
     var i;
     for (i = 0; i < evts.length; i++) {

--- a/pretender.js
+++ b/pretender.js
@@ -133,23 +133,22 @@ function interceptor(pretender) {
     }
   };
 
-  // event types to handle on the xhr
-  var evts = ['error', 'timeout', 'abort'];
-
-  // event types to handle on the xhr.upload
-  var uploadEvents = ['progress'];
-
-  // properties to copy from the native xhr to fake xhr
-  var lifecycleProps = ['readyState', 'responseText', 'responseXML', 'status', 'statusText'];
 
   function createPassthrough(fakeXHR) {
+    // event types to handle on the xhr
+    var evts = ['error', 'timeout', 'abort', 'readystatechange'];
+
+    // event types to handle on the xhr.upload
+    var uploadEvents = ['progress'];
+
+    // properties to copy from the native xhr to fake xhr
+    var lifecycleProps = ['readyState', 'responseText', 'responseXML', 'status', 'statusText'];
+
     var xhr = fakeXHR._passthroughRequest = new pretender._nativeXMLHttpRequest();
 
-    // Use onload instead of onreadystatechange if the browser supports it
+    // Use onload if the browser supports it
     if ('onload' in xhr) {
       evts.push('load');
-    } else {
-      evts.push('readystatechange');
     }
 
     // add progress event for async calls
@@ -183,6 +182,8 @@ function interceptor(pretender) {
       };
     }
 
+    xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
+
     // set the on- handler on the native xhr's `upload` property for
     // the given eventType
     function createUploadHandler(eventType) {
@@ -201,7 +202,6 @@ function interceptor(pretender) {
       createUploadHandler(uploadEvents[i]);
     }
 
-    xhr.open(fakeXHR.method, fakeXHR.url, fakeXHR.async, fakeXHR.username, fakeXHR.password);
     if (fakeXHR.async) {
       xhr.timeout = fakeXHR.timeout;
       xhr.withCredentials = fakeXHR.withCredentials;

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -98,17 +98,19 @@ asyncTest('synchronous request does not have timeout, withCredentials and onprog
 
 test('asynchronous request fires events', function(assert) {
   var done = assert.async();
-  assert.expect(4);
+  assert.expect(6);
 
   pretender.post('/some/:route', pretender.passthrough);
 
   var onEvents = {
     load: false,
-    progress: false
+    progress: false,
+    readystatechange: false
   };
   var listenerEvents = {
     load: false,
-    progress: false
+    progress: false,
+    readystatechange: false
   };
 
   var xhr = new window.XMLHttpRequest();
@@ -132,6 +134,20 @@ test('asynchronous request fires events', function(assert) {
     finishNext();
   };
 
+  xhr.addEventListener('readystatechange', function _load() {
+    if (xhr.readyState == 4) {
+      listenerEvents.readystatechange = true;
+      finishNext();
+    }
+  });
+
+  xhr.onreadystatechange = function _onload() {
+    if (xhr.readyState == 4) {
+      onEvents.readystatechange = true;
+      finishNext();
+    }
+  };
+
   xhr.send();
 
   // call `finish` in next tick to ensure both load event handlers
@@ -147,9 +163,11 @@ test('asynchronous request fires events', function(assert) {
 
       assert.ok(onEvents.load, 'onload called');
       assert.ok(onEvents.progress, 'onprogress called');
+      assert.ok(onEvents.readystatechange, 'onpreadystate called');
 
       assert.ok(listenerEvents.load, 'load listener called');
       assert.ok(listenerEvents.progress, 'progress listener called');
+      assert.ok(listenerEvents.readystatechange, 'readystate listener called');
 
       done();
     }

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -41,6 +41,22 @@ asyncTest('allows matched paths to be pass-through', function(assert) {
   });
 });
 
+asyncTest('passthrough request calls jQuery v1 handler', function(assert) {
+  jQuery2 = jQuery.noConflict(true);
+  pretender.get('/some/:route', pretender.passthrough);
+
+  assert.ok(/^1/.test(jQuery.fn.jquery));
+  jQuery.ajax({
+    url: '/some/path',
+    error: function(xhr) {
+      assert.equal(xhr.status, 404);
+      jQuery = $ = jQuery2;
+      assert.ok(/^2/.test(jQuery.fn.jquery));
+      QUnit.start();
+    }
+  });
+});
+
 asyncTest('asynchronous request with pass-through has timeout, withCredentials and onprogress event', function(assert) {
   function testXHR() {
     this.pretender = pretender;

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -42,7 +42,7 @@ asyncTest('allows matched paths to be pass-through', function(assert) {
 });
 
 asyncTest('passthrough request calls jQuery v1 handler', function(assert) {
-  jQuery2 = jQuery.noConflict(true);
+  var jQuery2 = jQuery.noConflict(true);
   pretender.get('/some/:route', pretender.passthrough);
 
   assert.ok(/^1/.test(jQuery.fn.jquery));

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -163,7 +163,7 @@ test('asynchronous request fires events', function(assert) {
 
       assert.ok(onEvents.load, 'onload called');
       assert.ok(onEvents.progress, 'onprogress called');
-      assert.ok(onEvents.readystatechange, 'onpreadystate called');
+      assert.ok(onEvents.readystatechange, 'onreadystate called');
 
       assert.ok(listenerEvents.load, 'load listener called');
       assert.ok(listenerEvents.progress, 'progress listener called');


### PR DESCRIPTION
- Add `readystatechange` to xhr events regardless of the browser supporting `onload`, for ajax implementations that still rely on readystatechange (eg jQuery 1.x #85 )
- Move `evts` into function closure so multiple calls to `createPassthrough` don't result in duplicate entries in `evts`.