### PR TITLE
updates FakeXMLHttpRequest to fix empty event bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "./pretender.js"
   ],
   "dependencies": {
-    "FakeXMLHttpRequest": "~1.2.1",
+    "FakeXMLHttpRequest": "~1.3.0",
     "route-recognizer": "~0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/pretenderjs/FakeXMLHttpRequest/pull/19

