### PR TITLE
pass headers to prepareBody

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -323,7 +323,7 @@ Pretender.prototype = {
 
         var status = statusHeadersAndBody[0],
             headers = this.prepareHeaders(statusHeadersAndBody[1]),
-            body = this.prepareBody(statusHeadersAndBody[2]),
+            body = this.prepareBody(statusHeadersAndBody[2], headers),
             pretender = this;
 
         this.handleResponse(request, async, function() {


### PR DESCRIPTION
passing headers to prepareBody can be useful when you want to serialize depending `content-type` header, for example if it is `text/...`