### PR TITLE
Use nested QUnit style

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.5.0",
     "karma-phantomjs-launcher": "^0.2.0",
-    "karma-qunit": "^0.1.3",
+    "karma-qunit": "^0.1.8",
     "phantomjs": "^1.9.17",
-    "qunitjs": "^1.18.0"
+    "qunitjs": "^1.20.0"
   },
   "dependencies": {
     "fake-xml-http-request": "^1.3.0",

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -1,459 +1,462 @@
-var pretender;
-module('pretender invoking', {
-  setup: function() {
-    pretender = new Pretender();
-  },
-  teardown: function() {
-    if (pretender) {
-      pretender.shutdown();
-    }
-    pretender = null;
-  }
-});
+var describe = QUnit.module;
+var it = QUnit.test;
 
-test('a mapping function is optional', function() {
-  var wasCalled;
-
-  pretender.get('/some/path', function() {
-    wasCalled = true;
+describe('pretender invoking', function(config) {
+  config.beforeEach(function() {
+    this.pretender = new Pretender();
   });
 
-  $.ajax({url: '/some/path'});
-  ok(wasCalled);
-});
+  config.afterEach(function() {
+    this.pretender.shutdown();
+  });
 
-test('mapping can be called directly', function() {
-  var wasCalled;
-  function map() {
-    this.get('/some/path', function() {
+  it('a mapping function is optional', function() {
+    var wasCalled;
+
+    this.pretender.get('/some/path', function() {
       wasCalled = true;
     });
-  }
 
-  pretender.map(map);
-
-  $.ajax({url: '/some/path'});
-  ok(wasCalled);
-});
-
-test('params are passed', function() {
-  var params;
-  pretender.get('/some/path/:id', function(request) {
-    params = request.params;
+    $.ajax({url: '/some/path'});
+    ok(wasCalled);
   });
 
-  $.ajax({url: '/some/path/1'});
-  equal(params.id, 1);
-});
-
-test('queryParams are passed', function() {
-  var params;
-  pretender.get('/some/path', function(request) {
-    params = request.queryParams;
-  });
-
-  $.ajax({url: '/some/path?zulu=nation'});
-  equal(params.zulu, 'nation');
-});
-
-test('request body is accessible', function() {
-  var params;
-  pretender.post('/some/path/1', function(request) {
-    params = request.requestBody;
-  });
-
-  $.ajax({
-    method: 'post',
-    url: '/some/path/1',
-    data: {
-      ok: true
+  it('mapping can be called directly', function() {
+    var wasCalled;
+    function map() {
+      this.get('/some/path', function() {
+        wasCalled = true;
+      });
     }
-  });
-  equal(params, 'ok=true');
-});
 
-test('request headers are accessible', function() {
-  var headers;
-  pretender.post('/some/path/1', function(request) {
-    headers = request.requestHeaders;
+    this.pretender.map(map);
+
+    $.ajax({url: '/some/path'});
+    ok(wasCalled);
   });
 
-  $.ajax({
-    method: 'post',
-    url: '/some/path/1',
-    headers: {
-      'A-Header': 'value'
-    }
-  });
-  equal(headers['A-Header'], 'value');
-});
+  it('params are passed', function() {
+    var params;
+    this.pretender.get('/some/path/:id', function(request) {
+      params = request.params;
+    });
 
-test('adds requests to the list of handled requests', function() {
-  var params;
-  pretender.get('/some/path', function(request) {
-    params = request.queryParams;
+    $.ajax({url: '/some/path/1'});
+    equal(params.id, 1);
   });
 
-  $.ajax({url: '/some/path'});
+  it('queryParams are passed', function() {
+    var params;
+    this.pretender.get('/some/path', function(request) {
+      params = request.queryParams;
+    });
 
-  var req = pretender.handledRequests[0];
-  equal(req.url, '/some/path');
-});
-
-test('increments the handler\'s request count', function() {
-  var handler = function(req) {};
-
-  pretender.get('/some/path', handler);
-
-  $.ajax({url: '/some/path'});
-
-  equal(handler.numberOfCalls, 1);
-});
-
-test('handledRequest is called', function(assert) {
-  var done = assert.async();
-
-  var json = '{foo: "bar"}';
-  pretender.get('/some/path', function(req) {
-    return [200, {}, json];
+    $.ajax({url: '/some/path?zulu=nation'});
+    equal(params.zulu, 'nation');
   });
 
-  pretender.handledRequest = function(verb, path, request) {
-    ok(true, 'handledRequest hook was called');
-    equal(verb, 'GET');
-    equal(path, '/some/path');
-    equal(request.responseText, json);
-    equal(request.status, '200');
-    done();
-  };
+  it('request body is accessible', function() {
+    var params;
+    this.pretender.post('/some/path/1', function(request) {
+      params = request.requestBody;
+    });
 
-  $.ajax({url: '/some/path'});
-});
-
-test('prepareBody is called', function(assert) {
-  var done = assert.async();
-
-  var obj = {foo: 'bar'};
-  pretender.prepareBody = JSON.stringify;
-  pretender.get('/some/path', function(req) {
-    return [200, {}, obj];
+    $.ajax({
+      method: 'post',
+      url: '/some/path/1',
+      data: {
+        ok: true
+      }
+    });
+    equal(params, 'ok=true');
   });
 
-  $.ajax({
-    url: '/some/path',
-    success: function(resp) {
-      deepEqual(JSON.parse(resp), obj);
+  it('request headers are accessible', function() {
+    var headers;
+    this.pretender.post('/some/path/1', function(request) {
+      headers = request.requestHeaders;
+    });
+
+    $.ajax({
+      method: 'post',
+      url: '/some/path/1',
+      headers: {
+        'A-Header': 'value'
+      }
+    });
+    equal(headers['A-Header'], 'value');
+  });
+
+  it('adds requests to the list of handled requests', function() {
+    var params;
+    this.pretender.get('/some/path', function(request) {
+      params = request.queryParams;
+    });
+
+    $.ajax({url: '/some/path'});
+
+    var req = this.pretender.handledRequests[0];
+    equal(req.url, '/some/path');
+  });
+
+  it('increments the handler\'s request count', function() {
+    var handler = function(req) {};
+
+    this.pretender.get('/some/path', handler);
+
+    $.ajax({url: '/some/path'});
+
+    equal(handler.numberOfCalls, 1);
+  });
+
+  it('handledRequest is called', function(assert) {
+    var done = assert.async();
+
+    var json = '{foo: "bar"}';
+    this.pretender.get('/some/path', function(req) {
+      return [200, {}, json];
+    });
+
+    this.pretender.handledRequest = function(verb, path, request) {
+      ok(true, 'handledRequest hook was called');
+      equal(verb, 'GET');
+      equal(path, '/some/path');
+      equal(request.responseText, json);
+      equal(request.status, '200');
       done();
-    }
-  });
-});
+    };
 
-test('prepareHeaders is called', function(assert) {
-  var done = assert.async();
-
-  pretender.prepareHeaders = function(headers) {
-    headers['X-WAS-CALLED'] = 'YES';
-    return headers;
-  };
-
-  pretender.get('/some/path', function(req) {
-    return [200, {}, ''];
+    $.ajax({url: '/some/path'});
   });
 
-  $.ajax({
-    url: '/some/path',
-    complete: function(xhr) {
-      equal(xhr.getResponseHeader('X-WAS-CALLED'), 'YES');
-      done();
-    }
-  });
-});
+  it('prepareBody is called', function(assert) {
+    var done = assert.async();
 
-test('will use the latest defined handler', function() {
-  expect(1);
-  var latestHandlerWasCalled = false;
-  pretender.get('/some/path', function(request) {
-    ok(false);
-  });
-  pretender.get('/some/path', function(request) {
-    latestHandlerWasCalled = true;
-  });
-  $.ajax({url: '/some/path'});
-  ok(latestHandlerWasCalled, 'calls the latest handler');
-});
+    var obj = {foo: 'bar'};
+    this.pretender.prepareBody = JSON.stringify;
+    this.pretender.get('/some/path', function(req) {
+      return [200, {}, obj];
+    });
 
-test('will error when using fully qualified URLs instead of paths', function() {
-  pretender.get('/some/path', function(request) {
-    return [200, {}, ''];
+    $.ajax({
+      url: '/some/path',
+      success: function(resp) {
+        deepEqual(JSON.parse(resp), obj);
+        done();
+      }
+    });
   });
 
-  throws(function() {
-    pretender.handleRequest({url: 'http://myserver.com/some/path'});
+  it('prepareHeaders is called', function(assert) {
+    var done = assert.async();
+
+    this.pretender.prepareHeaders = function(headers) {
+      headers['X-WAS-CALLED'] = 'YES';
+      return headers;
+    };
+
+    this.pretender.get('/some/path', function(req) {
+      return [200, {}, ''];
+    });
+
+    $.ajax({
+      url: '/some/path',
+      complete: function(xhr) {
+        equal(xhr.getResponseHeader('X-WAS-CALLED'), 'YES');
+        done();
+      }
+    });
   });
 
-});
+  it('will use the latest defined handler', function() {
+    expect(1);
 
-test('is resolved asynchronously', function(assert) {
-  var done = assert.async();
-  var val = 'unset';
-
-  pretender.get('/some/path', function(request) {
-    return [200, {}, ''];
+    var latestHandlerWasCalled = false;
+    this.pretender.get('/some/path', function(request) {
+      ok(false);
+    });
+    this.pretender.get('/some/path', function(request) {
+      latestHandlerWasCalled = true;
+    });
+    $.ajax({url: '/some/path'});
+    ok(latestHandlerWasCalled, 'calls the latest handler');
   });
 
-  $.ajax({
-    url: '/some/path',
-    complete: function() {
-      equal(val, 'set');
-      done();
-    }
+  it('will error when using fully qualified URLs instead of paths', function() {
+    var pretender = this.pretender;
+
+    pretender.get('/some/path', function(request) {
+      return [200, {}, ''];
+    });
+
+    throws(function() {
+      pretender.handleRequest({url: 'http://myserver.com/some/path'});
+    });
+
   });
 
-  equal(val, 'unset');
-  val = 'set';
-});
+  it('is resolved asynchronously', function(assert) {
+    var done = assert.async();
+    var val = 'unset';
 
-test('can be resolved synchronous', function() {
-  var val = 0;
+    this.pretender.get('/some/path', function(request) {
+      return [200, {}, ''];
+    });
 
-  pretender.get('/some/path', function(request) {
-    return [200, {}, ''];
-  }, false);
+    $.ajax({
+      url: '/some/path',
+      complete: function() {
+        equal(val, 'set');
+        done();
+      }
+    });
 
-  $.ajax({
-    url: '/some/path',
-    complete: function() {
+    equal(val, 'unset');
+    val = 'set';
+  });
+
+  it('can be resolved synchronous', function() {
+    var val = 0;
+
+    this.pretender.get('/some/path', function(request) {
+      return [200, {}, ''];
+    }, false);
+
+    $.ajax({
+      url: '/some/path',
+      complete: function() {
+        equal(val, 0);
+        val++;
+      }
+    });
+
+    equal(val, 1);
+  });
+
+  it('can be both asynchronous or synchronous based on an async function', function(assert) {
+    var done = assert.async();
+
+    var isAsync = false;
+    var val = 0;
+
+    this.pretender.get('/some/path', function(request) {
+      return [200, {}, ''];
+    }, function() {
+      return isAsync;
+    });
+
+    $.ajax({
+      url: '/some/path',
+      complete: function() {
+        equal(val, 0);
+        val++;
+      }
+    });
+
+    equal(val, 1);
+    val++;
+
+    isAsync = 0;
+
+    $.ajax({
+      url: '/some/path',
+      complete: function() {
+        equal(val, 3);
+        done();
+      }
+    });
+
+    equal(val, 2);
+    val++;
+  });
+
+  it('can be configured to resolve after a specified time', function(assert) {
+    var done = assert.async();
+
+    var val = 0;
+
+    this.pretender.get('/some/path', function(request) {
+      return [200, {}, ''];
+    }, 100);
+
+    $.ajax({
+      url: '/some/path',
+      complete: function() {
+        equal(val, 1);
+        done();
+      }
+    });
+
+    setTimeout(function() {
       equal(val, 0);
       val++;
-    }
+    }, 0);
   });
 
-  equal(val, 1);
-});
+  it('can be configured to require manually resolution', function() {
+    var val = 0;
+    var req = $.ajaxSettings.xhr();
 
-test('can be both asynchronous or synchronous based on an async function', function(assert) {
-  var done = assert.async();
+    this.pretender.get('/some/path', function(request) {
+      return [200, {}, ''];
+    }, true);
 
-  var isAsync = false;
-  var val = 0;
+    $.ajax({
+      url: '/some/path',
+      xhr: function() {
+        // use the xhr we already made and have a reference to
+        return req;
+      },
+      complete: function() {
+        equal(val, 1);
+        val++;
+      }
+    });
 
-  pretender.get('/some/path', function(request) {
-    return [200, {}, ''];
-  }, function() {
-    return isAsync;
-  });
-
-  $.ajax({
-    url: '/some/path',
-    complete: function() {
-      equal(val, 0);
-      val++;
-    }
-  });
-
-  equal(val, 1);
-  val++;
-
-  isAsync = 0;
-
-  $.ajax({
-    url: '/some/path',
-    complete: function() {
-      equal(val, 3);
-      done();
-    }
-  });
-
-  equal(val, 2);
-  val++;
-});
-
-test('can be configured to resolve after a specified time', function(assert) {
-  var done = assert.async();
-
-  var val = 0;
-
-  pretender.get('/some/path', function(request) {
-    return [200, {}, ''];
-  }, 100);
-
-  $.ajax({
-    url: '/some/path',
-    complete: function() {
-      equal(val, 1);
-      done();
-    }
-  });
-
-  setTimeout(function() {
     equal(val, 0);
     val++;
-  }, 0);
-});
 
-test('can be configured to require manually resolution', function() {
-  var val = 0;
-  var req = $.ajaxSettings.xhr();
+    this.pretender.resolve(req);
 
-  pretender.get('/some/path', function(request) {
-    return [200, {}, ''];
-  }, true);
-
-  $.ajax({
-    url: '/some/path',
-    xhr: function() {
-      // use the xhr we already made and have a reference to
-      return req;
-    },
-    complete: function() {
-      equal(val, 1);
-      val++;
-    }
+    equal(val, 2);
   });
 
-  equal(val, 0);
-  val++;
+  it('requiresManualResolution returns true for endpoints configured with `true` for async', function() {
+    this.pretender.get('/some/path', function(request) {}, true);
+    this.pretender.get('/some/other/path', function() {});
 
-  pretender.resolve(req);
-
-  equal(val, 2);
-});
-
-test('requiresManualResolution returns true for endpoints configured with `true` for async', function() {
-  pretender.get('/some/path', function(request) {}, true);
-  pretender.get('/some/other/path', function() {});
-
-  ok(pretender.requiresManualResolution('get', '/some/path'));
-  ok(!pretender.requiresManualResolution('get', '/some/other/path'));
-});
-
-test('async requests with `onprogress` upload events in the upload ' +
-  ' trigger a progress event each 50ms', function(assert) {
-  var done = assert.async();
-  var progressEventCount = 0;
-  pretender.post('/uploads', function(request) {
-    return [200, {}, ''];
-  }, 300);
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/uploads');
-  xhr.upload.onprogress = function(e) {
-    progressEventCount++;
-  };
-  xhr.onload = function() {
-    equal(progressEventCount, 5, 'In a request of 300ms the progress event has been fired 5 times');
-    done();
-  };
-  xhr.send('some data');
-});
-
-test('`onprogress` upload events don\'t keep firing once the request has ended', function(assert) {
-  var done = assert.async();
-  var progressEventCount = 0;
-  pretender.post('/uploads', function(request) {
-    return [200, {}, ''];
-  }, 210);
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/uploads');
-  xhr.upload.onprogress = function(e) {
-    progressEventCount++;
-  };
-  xhr.send('some data');
-  setTimeout(function() {
-    equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
-    done();
-  }, 510);
-});
-
-test('no progress upload events are fired after the request is aborted', function(assert) {
-  var done = assert.async();
-  var progressEventCount = 0;
-
-  pretender.post('/uploads', function(request) {
-    return [200, {}, ''];
-  }, 210);
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/uploads');
-  xhr.upload.onprogress = function(e) { progressEventCount++; };
-  xhr.send('some data');
-  setTimeout(function() { xhr.abort(); }, 90);
-  setTimeout(function() {
-    equal(progressEventCount, 1, 'only one progress event was triggered because the request was aborted');
-    done();
-  }, 220);
-});
-
-test('async requests with `onprogress` events trigger a progress event each 50ms', function(assert) {
-  var done = assert.async();
-  var progressEventCount = 0;
-  pretender.get('/downloads', function(request) {
-    return [200, {}, ''];
-  }, 300);
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('GET', '/downloads');
-  xhr.onprogress = function(e) {
-    progressEventCount++;
-  };
-  xhr.onload = function() {
-    equal(progressEventCount, 5, 'In a request of 300ms the progress event has been fired 5 times');
-    done();
-  };
-  xhr.send('some data');
-});
-
-test('`onprogress` download events don\'t keep firing once the request has ended', function(assert) {
-  var done = assert.async();
-  var progressEventCount = 0;
-  pretender.get('/downloads', function(request) {
-    return [200, {}, ''];
-  }, 210);
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('GET', '/downloads');
-  xhr.onprogress = function(e) {
-    progressEventCount++;
-  };
-  xhr.send('some data');
-  setTimeout(function() {
-    equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
-    done();
-  }, 510);
-});
-
-test('no progress download events are fired after the request is aborted', function(assert) {
-  var done = assert.async();
-  var progressEventCount = 0;
-
-  pretender.get('/downloads', function(request) {
-    return [200, {}, ''];
-  }, 210);
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('GET', '/downloads');
-  xhr.onprogress = function(e) { progressEventCount++; };
-  xhr.send('some data');
-  setTimeout(function() { xhr.abort(); }, 90);
-  setTimeout(function() {
-    equal(progressEventCount, 1, 'only one progress event was triggered because the request was aborted');
-    done();
-  }, 220);
-});
-
-test('resolves cross-origin requests', function() {
-
-  var url = 'http://status.github.com/api/status';
-  var payload = 'it works!';
-  var wasCalled;
-
-  pretender.get(url, function() {
-    wasCalled = true;
-    return [200, {}, payload];
+    ok(this.pretender.requiresManualResolution('get', '/some/path'));
+    ok(!this.pretender.requiresManualResolution('get', '/some/other/path'));
   });
 
-  $.ajax({url: url});
-  ok(wasCalled);
+  it('async requests with `onprogress` upload events in the upload ' +
+    ' trigger a progress event each 50ms', function(assert) {
+    var done = assert.async();
+    var progressEventCount = 0;
+    this.pretender.post('/uploads', function(request) {
+      return [200, {}, ''];
+    }, 300);
 
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/uploads');
+    xhr.upload.onprogress = function(e) {
+      progressEventCount++;
+    };
+    xhr.onload = function() {
+      equal(progressEventCount, 5, 'In a request of 300ms the progress event has been fired 5 times');
+      done();
+    };
+    xhr.send('some data');
+  });
+
+  it('`onprogress` upload events don\'t keep firing once the request has ended', function(assert) {
+    var done = assert.async();
+    var progressEventCount = 0;
+    this.pretender.post('/uploads', function(request) {
+      return [200, {}, ''];
+    }, 210);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/uploads');
+    xhr.upload.onprogress = function(e) {
+      progressEventCount++;
+    };
+    xhr.send('some data');
+    setTimeout(function() {
+      equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
+      done();
+    }, 510);
+  });
+
+  it('no progress upload events are fired after the request is aborted', function(assert) {
+    var done = assert.async();
+    var progressEventCount = 0;
+
+    this.pretender.post('/uploads', function(request) {
+      return [200, {}, ''];
+    }, 210);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/uploads');
+    xhr.upload.onprogress = function(e) { progressEventCount++; };
+    xhr.send('some data');
+    setTimeout(function() { xhr.abort(); }, 90);
+    setTimeout(function() {
+      equal(progressEventCount, 1, 'only one progress event was triggered because the request was aborted');
+      done();
+    }, 220);
+  });
+
+  it('async requests with `onprogress` events trigger a progress event each 50ms', function(assert) {
+    var done = assert.async();
+    var progressEventCount = 0;
+    this.pretender.get('/downloads', function(request) {
+      return [200, {}, ''];
+    }, 300);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('GET', '/downloads');
+    xhr.onprogress = function(e) {
+      progressEventCount++;
+    };
+    xhr.onload = function() {
+      equal(progressEventCount, 5, 'In a request of 300ms the progress event has been fired 5 times');
+      done();
+    };
+    xhr.send('some data');
+  });
+
+  it('`onprogress` download events don\'t keep firing once the request has ended', function(assert) {
+    var done = assert.async();
+    var progressEventCount = 0;
+    this.pretender.get('/downloads', function(request) {
+      return [200, {}, ''];
+    }, 210);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('GET', '/downloads');
+    xhr.onprogress = function(e) {
+      progressEventCount++;
+    };
+    xhr.send('some data');
+    setTimeout(function() {
+      equal(progressEventCount, 4, 'No `onprogress` events are fired after the the request finalizes');
+      done();
+    }, 510);
+  });
+
+  it('no progress download events are fired after the request is aborted', function(assert) {
+    var done = assert.async();
+    var progressEventCount = 0;
+
+    this.pretender.get('/downloads', function(request) {
+      return [200, {}, ''];
+    }, 210);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('GET', '/downloads');
+    xhr.onprogress = function(e) { progressEventCount++; };
+    xhr.send('some data');
+    setTimeout(function() { xhr.abort(); }, 90);
+    setTimeout(function() {
+      equal(progressEventCount, 1, 'only one progress event was triggered because the request was aborted');
+      done();
+    }, 220);
+  });
+
+  it('resolves cross-origin requests', function() {
+
+    var url = 'http://status.github.com/api/status';
+    var payload = 'it works!';
+    var wasCalled;
+
+    this.pretender.get(url, function() {
+      wasCalled = true;
+      return [200, {}, payload];
+    });
+
+    $.ajax({url: url});
+    ok(wasCalled);
+  });
 });
+

--- a/test/creation_test.js
+++ b/test/creation_test.js
@@ -1,53 +1,57 @@
 var pretender;
-module('pretender creation', {
-  teardown: function() {
+var describe = QUnit.module;
+var it = QUnit.test;
+
+describe('pretender creation', function(config) {
+  config.afterEach(function() {
     if (pretender) {
       pretender.shutdown();
     }
     pretender = null;
-  }
+  });
+
+  test('a mapping function is optional', function(assert) {
+    var result = false;
+    try {
+      pretender = new Pretender();
+      result = true;
+    } catch (e) {
+      // fail
+    }
+
+    assert.ok(true, 'does not raise');
+  });
+
+  test('many maps can be passed on creation', function(assert) {
+    var aWasCalled = false;
+    var bWasCalled = false;
+
+    var mapA = function() {
+      this.get('/some/path', function() {
+        aWasCalled = true;
+      });
+    };
+
+    var mapB = function() {
+      this.get('/other/path', function() {
+        bWasCalled = true;
+      });
+    };
+
+    pretender = new Pretender(mapA, mapB);
+
+    $.ajax({url: '/some/path'});
+    $.ajax({url: '/other/path'});
+
+    assert.ok(aWasCalled);
+    assert.ok(bWasCalled);
+  });
+
+  test('an error is thrown when a request handler is missing', function(assert) {
+    assert.throws(function() {
+      pretender = new Pretender();
+      pretender.get('/path', undefined);
+    }, 'The function you tried passing to Pretender to handle GET /path is undefined or missing.');
+  });
 });
 
-test('a mapping function is optional', function(assert) {
-  var result = false;
-  try {
-    pretender = new Pretender();
-    result = true;
-  } catch (e) {
-    // fail
-  }
-
-  assert.ok(true, 'does not raise');
-});
-
-test('many maps can be passed on creation', function(assert) {
-  var aWasCalled = false;
-  var bWasCalled = false;
-
-  var mapA = function() {
-    this.get('/some/path', function() {
-      aWasCalled = true;
-    });
-  };
-
-  var mapB = function() {
-    this.get('/other/path', function() {
-      bWasCalled = true;
-    });
-  };
-
-  pretender = new Pretender(mapA, mapB);
-
-  $.ajax({url: '/some/path'});
-  $.ajax({url: '/other/path'});
-
-  assert.ok(aWasCalled);
-  assert.ok(bWasCalled);
-});
-
-test('an error is thrown when a request handler is missing', function(assert) {
-  assert.throws(function() {
-    pretender = new Pretender();
-    pretender.get('/path', undefined);
-  }, 'The function you tried passing to Pretender to handle GET /path is undefined or missing.');
-});

--- a/test/error_handler_test.js
+++ b/test/error_handler_test.js
@@ -1,25 +1,25 @@
-var pretender;
-module('pretender errored requests', {
-  setup: function() {
-    pretender = new Pretender();
-  },
-  teardown: function() {
-    if (pretender) {
-      pretender.shutdown();
-    }
-    pretender = null;
-  }
-});
+var describe = QUnit.module;
+var it = QUnit.test;
 
-test('calls erroredRequest', function(assert) {
-  pretender.get('/some/path', function() {
-    throw new Error('something in this handler broke!');
+describe('pretender errored requests', function(config) {
+  config.beforeEach(function() {
+    this.pretender = new Pretender();
   });
 
-  pretender.erroredRequest = function(verb, path, request, error) {
-    assert.ok(error);
-  };
+  config.afterEach(function() {
+    this.pretender.shutdown();
+  });
 
-  $.ajax({url: '/some/path'});
+  it('calls erroredRequest', function(assert) {
+    this.pretender.get('/some/path', function() {
+      throw new Error('something in this handler broke!');
+    });
+
+    this.pretender.erroredRequest = function(verb, path, request, error) {
+      assert.ok(error);
+    };
+
+    $.ajax({url: '/some/path'});
+  });
 });
 

--- a/test/hosts_test.js
+++ b/test/hosts_test.js
@@ -1,29 +1,38 @@
 var hosts;
+var describe = QUnit.module;
+var it = QUnit.test;
 
-module('Hosts', {
-  setup: function() {
+describe('Hosts', function(config) {
+  config.beforeEach(function() {
     hosts = new Pretender.Hosts();
-  }
-});
-
-test('forURL - returns a registry for a URL', function(assert) {
-  assert.ok(hosts.forURL('http://www.groupon.com/offers/skydiving'));
-});
-
-test('forURL - returns a registry for a relative path', function(assert) {
-  assert.ok(hosts.forURL('/offers/skydiving'));
-});
-
-test('forURL - returns different Registry objects for different hosts ', function(assert) {
-  var registry1 = hosts.forURL('/offers/dinner_out');
-  var registry2 = hosts.forURL('http://www.yahoo.com/offers/dinner_out');
-  registry1.GET.add({
-    path: 'http://www.yahoo.com/offers/dinner_out',
-    handler: function() {
-      return [200, {}, 'ok'];
-    }
   });
-  assert.ok(!registry2.GET.recognize('http://www.yahoo.com/offers/dinner_out'));
-  assert.ok(!registry1.GET.recognize('http://www.yahoo.com/offers/dinner_out'));
+
+  config.afterEach(function() {
+    hosts = undefined;
+  });
+
+  describe('#forURL', function() {
+    it('returns a registry for a URL', function(assert) {
+      assert.ok(hosts.forURL('http://www.groupon.com/offers/skydiving'));
+    });
+
+    it('returns a registry for a relative path', function(assert) {
+      assert.ok(hosts.forURL('/offers/skydiving'));
+    });
+
+    it('returns different Registry objects for different hosts ', function(assert) {
+      var registry1 = hosts.forURL('/offers/dinner_out');
+      var registry2 = hosts.forURL('http://www.yahoo.com/offers/dinner_out');
+      registry1.GET.add({
+        path: 'http://www.yahoo.com/offers/dinner_out',
+        handler: function() {
+          return [200, {}, 'ok'];
+        }
+      });
+      assert.ok(!registry2.GET.recognize('http://www.yahoo.com/offers/dinner_out'));
+      assert.ok(!registry1.GET.recognize('http://www.yahoo.com/offers/dinner_out'));
+    });
+  });
 });
+
 

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -1,240 +1,253 @@
-var pretender, originalXMLHttpRequest;
-module('pretender passthrough', {
-  setup: function() {
+var originalXMLHttpRequest;
+var describe = QUnit.module;
+var it = QUnit.test;
+
+describe('passthrough requests',  function(config) {
+  config.beforeEach(function() {
     originalXMLHttpRequest = window.XMLHttpRequest;
-    pretender = new Pretender();
-  },
-  teardown: function() {
-    if (pretender) {
-      pretender.shutdown();
-    }
-    pretender = null;
+    this.pretender = new Pretender();
+  });
+
+  config.afterEach(function() {
+    this.pretender.shutdown();
     window.XMLHttpRequest = originalXMLHttpRequest;
-  }
-});
-
-asyncTest('allows matched paths to be pass-through', function(assert) {
-  pretender.post('/some/:route', pretender.passthrough);
-
-  var passthroughInvoked = false;
-  pretender.passthroughRequest = function(verb, path, request) {
-    passthroughInvoked = true;
-    assert.equal(verb, 'POST');
-    assert.equal(path, '/some/path');
-    assert.equal(request.requestBody, 'some=data');
-  };
-
-  $.ajax({
-    url: '/some/path',
-    method: 'POST',
-    headers: {
-      'test-header': 'value'
-    },
-    data: {
-      some: 'data'
-    },
-    error: function(xhr) {
-      assert.equal(xhr.status, 404);
-      assert.ok(passthroughInvoked);
-      QUnit.start();
-    }
   });
-});
 
-asyncTest('passthrough request calls jQuery v1 handler', function(assert) {
-  var jQuery2 = jQuery.noConflict(true);
-  pretender.get('/some/:route', pretender.passthrough);
+  asyncTest('allows matched paths to be pass-through', function(assert) {
+    var pretender = this.pretender;
 
-  assert.ok(/^1/.test(jQuery.fn.jquery));
-  jQuery.ajax({
-    url: '/some/path',
-    error: function(xhr) {
-      assert.equal(xhr.status, 404);
-      jQuery = $ = jQuery2;
-      assert.ok(/^2/.test(jQuery.fn.jquery));
-      QUnit.start();
-    }
-  });
-});
+    pretender.post('/some/:route', pretender.passthrough);
 
-asyncTest('asynchronous request with pass-through has timeout, withCredentials and onprogress event', function(assert) {
-  function testXHR() {
-    this.pretender = pretender;
-    this.open = function() {};
-    this.setRequestHeader = function() {};
-    this.upload = {};
-    this.send = {
-      pretender: pretender,
-      apply: function(xhr, argument) {
-        assert.ok('timeout' in xhr);
-        assert.ok('withCredentials' in xhr);
-        assert.ok('onprogress' in xhr);
-        this.pretender.resolve(xhr);
+    var passthroughInvoked = false;
+    pretender.passthroughRequest = function(verb, path, request) {
+      passthroughInvoked = true;
+      assert.equal(verb, 'POST');
+      assert.equal(path, '/some/path');
+      assert.equal(request.requestBody, 'some=data');
+    };
+
+    $.ajax({
+      url: '/some/path',
+      method: 'POST',
+      headers: {
+        'test-header': 'value'
+      },
+      data: {
+        some: 'data'
+      },
+      error: function(xhr) {
+        assert.equal(xhr.status, 404);
+        assert.ok(passthroughInvoked);
         QUnit.start();
       }
-    };
-  }
-  pretender._nativeXMLHttpRequest = testXHR;
+    });
+  });
 
-  pretender.post('/some/path', pretender.passthrough);
+  asyncTest('passthrough request calls jQuery v1 handler', function(assert) {
+    var pretender = this.pretender;
 
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/some/path');
-  xhr.timeout = 1000;
-  xhr.withCredentials = true;
-  xhr.send('some data');
-});
+    var jQuery2 = jQuery.noConflict(true);
+    pretender.get('/some/:route', pretender.passthrough);
 
-asyncTest('synchronous request does not have timeout, withCredentials and onprogress event', function(assert) {
-  function testXHR() {
-    this.open = function() {};
-    this.setRequestHeader = function() {};
-    this.upload = {};
-    this.send = {
-      pretender: pretender,
-      apply: function(xhr, argument) {
-        assert.ok(!('timeout' in xhr));
-        assert.ok(!('withCredentials' in xhr));
-        assert.ok(!('onprogress' in xhr));
-        this.pretender.resolve(xhr);
+    assert.ok(/^1/.test(jQuery.fn.jquery));
+    jQuery.ajax({
+      url: '/some/path',
+      error: function(xhr) {
+        assert.equal(xhr.status, 404);
+        jQuery = $ = jQuery2;
+        assert.ok(/^2/.test(jQuery.fn.jquery));
         QUnit.start();
       }
+    });
+  });
+
+  asyncTest('asynchronous request with pass-through has timeout,' +
+    'withCredentials and onprogress event', function(assert) {
+    var pretender = this.pretender;
+    function testXHR() {
+      this.pretender = pretender;
+      this.open = function() {};
+      this.setRequestHeader = function() {};
+      this.upload = {};
+      this.send = {
+        pretender: pretender,
+        apply: function(xhr, argument) {
+          assert.ok('timeout' in xhr);
+          assert.ok('withCredentials' in xhr);
+          assert.ok('onprogress' in xhr);
+          this.pretender.resolve(xhr);
+          QUnit.start();
+        }
+      };
+    }
+    pretender._nativeXMLHttpRequest = testXHR;
+
+    pretender.post('/some/path', pretender.passthrough);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/some/path');
+    xhr.timeout = 1000;
+    xhr.withCredentials = true;
+    xhr.send('some data');
+  });
+
+  asyncTest('synchronous request does not have timeout, withCredentials and onprogress event', function(assert) {
+    var pretender = this.pretender;
+    function testXHR() {
+      this.open = function() {};
+      this.setRequestHeader = function() {};
+      this.upload = {};
+      this.send = {
+        pretender: pretender,
+        apply: function(xhr, argument) {
+          assert.ok(!('timeout' in xhr));
+          assert.ok(!('withCredentials' in xhr));
+          assert.ok(!('onprogress' in xhr));
+          this.pretender.resolve(xhr);
+          QUnit.start();
+        }
+      };
+    }
+    pretender._nativeXMLHttpRequest = testXHR;
+
+    pretender.post('/some/path', pretender.passthrough);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/some/path', false);
+    xhr.timeout = 1000;
+    xhr.withCredentials = true;
+    xhr.send('some data');
+  });
+
+  test('asynchronous request fires events', function(assert) {
+    var pretender = this.pretender;
+    var done = assert.async();
+    assert.expect(6);
+
+    pretender.post('/some/:route', pretender.passthrough);
+
+    var onEvents = {
+      load: false,
+      progress: false,
+      readystatechange: false
     };
-  }
-  pretender._nativeXMLHttpRequest = testXHR;
+    var listenerEvents = {
+      load: false,
+      progress: false,
+      readystatechange: false
+    };
 
-  pretender.post('/some/path', pretender.passthrough);
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/some/otherpath');
 
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/some/path', false);
-  xhr.timeout = 1000;
-  xhr.withCredentials = true;
-  xhr.send('some data');
-});
+    xhr.addEventListener('progress', function _progress() {
+      listenerEvents.progress = true;
+    });
 
-test('asynchronous request fires events', function(assert) {
-  var done = assert.async();
-  assert.expect(6);
+    xhr.onprogress = function _onprogress() {
+      onEvents.progress = true;
+    };
 
-  pretender.post('/some/:route', pretender.passthrough);
-
-  var onEvents = {
-    load: false,
-    progress: false,
-    readystatechange: false
-  };
-  var listenerEvents = {
-    load: false,
-    progress: false,
-    readystatechange: false
-  };
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/some/otherpath');
-
-  xhr.addEventListener('progress', function _progress() {
-    listenerEvents.progress = true;
-  });
-
-  xhr.onprogress = function _onprogress() {
-    onEvents.progress = true;
-  };
-
-  xhr.addEventListener('load', function _load() {
-    listenerEvents.load = true;
-    finishNext();
-  });
-
-  xhr.onload = function _onload() {
-    onEvents.load = true;
-    finishNext();
-  };
-
-  xhr.addEventListener('readystatechange', function _load() {
-    if (xhr.readyState == 4) {
-      listenerEvents.readystatechange = true;
+    xhr.addEventListener('load', function _load() {
+      listenerEvents.load = true;
       finishNext();
-    }
-  });
+    });
 
-  xhr.onreadystatechange = function _onload() {
-    if (xhr.readyState == 4) {
-      onEvents.readystatechange = true;
+    xhr.onload = function _onload() {
+      onEvents.load = true;
       finishNext();
+    };
+
+    xhr.addEventListener('readystatechange', function _load() {
+      if (xhr.readyState == 4) {
+        listenerEvents.readystatechange = true;
+        finishNext();
+      }
+    });
+
+    xhr.onreadystatechange = function _onload() {
+      if (xhr.readyState == 4) {
+        onEvents.readystatechange = true;
+        finishNext();
+      }
+    };
+
+    xhr.send();
+
+    // call `finish` in next tick to ensure both load event handlers
+    // have a chance to fire.
+    function finishNext() {
+      setTimeout(finishOnce, 1);
     }
-  };
 
-  xhr.send();
+    var finished = false;
+    function finishOnce() {
+      if (!finished) {
+        finished = true;
 
-  // call `finish` in next tick to ensure both load event handlers
-  // have a chance to fire.
-  function finishNext() {
-    setTimeout(finishOnce, 1);
-  }
+        assert.ok(onEvents.load, 'onload called');
+        assert.ok(onEvents.progress, 'onprogress called');
+        assert.ok(onEvents.readystatechange, 'onreadystate called');
 
-  var finished = false;
-  function finishOnce() {
-    if (!finished) {
-      finished = true;
+        assert.ok(listenerEvents.load, 'load listener called');
+        assert.ok(listenerEvents.progress, 'progress listener called');
+        assert.ok(listenerEvents.readystatechange, 'readystate listener called');
 
-      assert.ok(onEvents.load, 'onload called');
-      assert.ok(onEvents.progress, 'onprogress called');
-      assert.ok(onEvents.readystatechange, 'onreadystate called');
-
-      assert.ok(listenerEvents.load, 'load listener called');
-      assert.ok(listenerEvents.progress, 'progress listener called');
-      assert.ok(listenerEvents.readystatechange, 'readystate listener called');
-
-      done();
+        done();
+      }
     }
-  }
-});
-
-test('asynchronous request fires upload progress events', function(assert) {
-  var done = assert.async();
-  assert.expect(2);
-
-  pretender.post('/some/:route', pretender.passthrough);
-
-  var onEvents = {
-    progress: false
-  };
-  var listenerEvents = {
-    progress: false
-  };
-
-  var xhr = new window.XMLHttpRequest();
-  xhr.open('POST', '/some/otherpath');
-
-  xhr.upload.addEventListener('progress', function _progress() {
-    listenerEvents.progress = true;
   });
 
-  xhr.upload.onprogress = function _onprogress() {
-    onEvents.progress = true;
-  };
+  test('asynchronous request fires upload progress events', function(assert) {
+    var pretender = this.pretender;
+    var done = assert.async();
+    assert.expect(2);
 
-  xhr.onload = function _onload() {
-    setTimeout(finish, 1);
-  };
+    pretender.post('/some/:route', pretender.passthrough);
 
-  xhr.send('some data');
+    var onEvents = {
+      progress: false
+    };
+    var listenerEvents = {
+      progress: false
+    };
 
-  // ensure the test ends
-  var failTimer = setTimeout(function() {
-    assert.ok(false, 'test timed out');
-    done();
-  }, 500);
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('POST', '/some/otherpath');
 
-  var finished = false;
-  function finish() {
-    if (!finished) {
-      finished = true;
-      clearTimeout(failTimer);
-      assert.ok(onEvents.progress, 'onprogress called');
-      assert.ok(listenerEvents.progress, 'progress listener called');
+    xhr.upload.addEventListener('progress', function _progress() {
+      listenerEvents.progress = true;
+    });
 
+    xhr.upload.onprogress = function _onprogress() {
+      onEvents.progress = true;
+    };
+
+    xhr.onload = function _onload() {
+      setTimeout(finish, 1);
+    };
+
+    xhr.send('some data');
+
+    // ensure the test ends
+    var failTimer = setTimeout(function() {
+      assert.ok(false, 'test timed out');
       done();
+    }, 500);
+
+    var finished = false;
+    function finish() {
+      if (!finished) {
+        finished = true;
+        clearTimeout(failTimer);
+        assert.ok(onEvents.progress, 'onprogress called');
+        assert.ok(listenerEvents.progress, 'progress listener called');
+
+        done();
+      }
     }
-  }
+  });
 });
+
+
+

--- a/test/registry_test.js
+++ b/test/registry_test.js
@@ -1,19 +1,20 @@
-var registry;
+var describe = QUnit.module;
+var it = QUnit.test;
 
-module('Registry', {
-  setup: function() {
-    registry = new Pretender.Registry();
-  }
-});
+describe('Registry', function(config) {
+  config.beforeEach(function() {
+    this.registry = new Pretender.Registry();
+  });
 
-test('has a "verbs" property', function() {
-  ok(registry.verbs);
-});
+  it('has a "verbs" property', function() {
+    ok(this.registry.verbs);
+  });
 
 
-test('supports all HTTP verbs', function(assert) {
-  var verbs = ['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
-  for (var v = 0; v < verbs.length; v++) {
-    assert.ok(registry.verbs[verbs[v]], 'supports ' + verbs[v]);
-  }
+  it('supports all HTTP verbs', function(assert) {
+    var verbs = ['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
+    for (var v = 0; v < verbs.length; v++) {
+      assert.ok(this.registry.verbs[verbs[v]], 'supports ' + verbs[v]);
+    }
+  });
 });

--- a/test/shutdown_test.js
+++ b/test/shutdown_test.js
@@ -1,27 +1,32 @@
-var pretender, nativeXMLHttpRequest;
-module('pretender shutdown', {
-  setup: function() {
+var nativeXMLHttpRequest;
+var describe = QUnit.module;
+var it = QUnit.test;
+
+describe('pretender shutdown', function(config) {
+  config.beforeEach(function() {
     nativeXMLHttpRequest = window.XMLHttpRequest;
-  },
-  shutdown: function() {
-    pretender = nativeXMLHttpRequest = null;
-  }
-});
-
-test('restores the native XMLHttpRequest object', function(assert) {
-  pretender = new Pretender();
-  assert.notEqual(window.XMLHttpRequest, nativeXMLHttpRequest);
-
-  pretender.shutdown();
-  assert.equal(window.XMLHttpRequest, nativeXMLHttpRequest);
-});
-
-test('warns if requests attempt to respond after shutdown', function(assert) {
-  pretender = new Pretender();
-  var request = new XMLHttpRequest();
-  pretender.shutdown();
-
-  assert.throws (function() {
-    request.send();
   });
+
+  config.afterEach(function() {
+    nativeXMLHttpRequest = null;
+  });
+
+  it('restores the native XMLHttpRequest object', function(assert) {
+    var pretender = new Pretender();
+    assert.notEqual(window.XMLHttpRequest, nativeXMLHttpRequest);
+
+    pretender.shutdown();
+    assert.equal(window.XMLHttpRequest, nativeXMLHttpRequest);
+  });
+
+  it('warns if requests attempt to respond after shutdown', function(assert) {
+    var pretender = new Pretender();
+    var request = new XMLHttpRequest();
+    pretender.shutdown();
+
+    assert.throws (function() {
+      request.send();
+    });
+  });
+
 });

--- a/test/undefined_response_test.js
+++ b/test/undefined_response_test.js
@@ -1,27 +1,25 @@
-var pretender;
-module('pretender undefined response', {
-  setup: function() {
-    pretender = new Pretender();
-  },
-  teardown: function() {
-    if (pretender) {
-      pretender.shutdown();
-    }
-    pretender = null;
-  }
-});
+var describe = QUnit.module;
+var it = QUnit.test;
 
-test('calls erroredRequest', function(assert) {
-  pretender.get('/some/path', function() {
-    // return nothing
+describe('retruning an undefined response', function(config) {
+  config.beforeEach(function() {
+    this.pretender = new Pretender();
+  });
+  config.afterEach(function() {
+    this.pretender.shutdown();
   });
 
-  pretender.erroredRequest = function(verb, path, request, error) {
-    var message = 'Nothing returned by handler for ' + path + '. ' +
-      'Remember to `return [status, headers, body];` in your route handler.';
-    assert.equal(error.message, message);
-  };
+  it('calls erroredRequest callback', function(assert) {
+    this.pretender.get('/some/path', function() {
+      // return nothing
+    });
 
-  $.ajax({url: '/some/path'});
+    this.pretender.erroredRequest = function(verb, path, request, error) {
+      var message = 'Nothing returned by handler for ' + path + '. ' +
+        'Remember to `return [status, headers, body];` in your route handler.';
+      assert.equal(error.message, message);
+    };
+
+    $.ajax({url: '/some/path'});
+  });
 });
-

--- a/test/undefined_route_test.js
+++ b/test/undefined_route_test.js
@@ -1,41 +1,42 @@
-var pretender;
-module('pretender route not defined', {
-  setup: function() {
-    pretender = new Pretender();
-  },
-  teardown: function() {
-    if (pretender) {
-      pretender.shutdown();
-    }
-    pretender = null;
-  }
-});
+var describe = QUnit.module;
+var it = QUnit.test;
 
-test('calls unhandledRequest', function(assert) {
-  pretender.unhandledRequest = function(verb, path) {
-    assert.equal('GET', verb);
-    assert.equal('not-defined', path);
-    assert.ok(true);
-  };
+describe('route not defined', function(config) {
+  config.beforeEach(function() {
+    this.pretender = new Pretender();
+  });
+  config.afterEach(function() {
+    this.pretender.shutdown();
+  });
 
-  $.ajax({
-    url: 'not-defined'
+  it('calls unhandledRequest', function(assert) {
+    this.pretender.unhandledRequest = function(verb, path) {
+      assert.equal('GET', verb);
+      assert.equal('not-defined', path);
+      assert.ok(true);
+    };
+
+    $.ajax({
+      url: 'not-defined'
+    });
+  });
+
+  it('errors by default', function(assert) {
+    var pretender = this.pretender;
+    var verb = 'GET';
+    var path = '/foo/bar';
+    assert.throws (function() {
+      pretender.unhandledRequest(verb, path);
+    }, 'Pretender intercepted GET /foo/bar but no handler was defined for this type of request');
+  });
+
+  it('adds the request to the array of unhandled requests by default', function(assert) {
+    $.ajax({
+      url: 'not-defined'
+    });
+
+    var req = this.pretender.unhandledRequests[0];
+    assert.equal(req.url, 'not-defined');
   });
 });
 
-test('errors by default', function(assert) {
-  var verb = 'GET';
-  var path = '/foo/bar';
-  assert.throws (function() {
-    pretender.unhandledRequest(verb, path);
-  }, 'Pretender intercepted GET /foo/bar but no handler was defined for this type of request');
-});
-
-test('adds the request to the array of unhandled requests by default', function(assert) {
-  $.ajax({
-    url: 'not-defined'
-  });
-
-  var req = pretender.unhandledRequests[0];
-  assert.equal(req.url, 'not-defined');
-});

--- a/test/url_parsing_test.js
+++ b/test/url_parsing_test.js
@@ -1,48 +1,54 @@
-module('parseURL', {});
+var describe = QUnit.module;
+var it = QUnit.test;
 
-var parseURL = Pretender.parseURL;
+describe('parseURL', function() {
+  var parseURL = Pretender.parseURL;
 
-function testUrl(assert, url, expectedParts) {
-  var parts = parseURL(url);
-  assert.ok(parts, 'Parts exist');
+  function testUrl(url, expectedParts) {
+    it('pathname, fullpath, protocol, hash and search are correct', function(assert) {
+      var parts = parseURL(url);
+      assert.ok(parts, 'Parts exist');
 
-  assert.equal(parts.protocol, expectedParts.protocol,  'protocol should be \"' + expectedParts.protocol + '\"');
-  assert.equal(parts.pathname, expectedParts.pathname, 'pathname should be \"' + expectedParts.pathname + '\"');
-  assert.equal(parts.host, expectedParts.host, 'hostname is equal to \"' + expectedParts.host + '\"');
-  assert.equal(parts.search, expectedParts.search, 'search should be \"' + expectedParts.search + '\"');
-  assert.equal(parts.hash, expectedParts.hash, 'hash should be \"' + expectedParts.search + '\"');
-  assert.equal(parts.fullpath, expectedParts.fullpath, 'fullpath should be \"' + expectedParts.fullpath + '\"');
-}
+      assert.equal(parts.protocol, expectedParts.protocol,  'protocol should be \"' + expectedParts.protocol + '\"');
+      assert.equal(parts.pathname, expectedParts.pathname, 'pathname should be \"' + expectedParts.pathname + '\"');
+      assert.equal(parts.host, expectedParts.host, 'hostname is equal to \"' + expectedParts.host + '\"');
+      assert.equal(parts.search, expectedParts.search, 'search should be \"' + expectedParts.search + '\"');
+      assert.equal(parts.hash, expectedParts.hash, 'hash should be \"' + expectedParts.search + '\"');
+      assert.equal(parts.fullpath, expectedParts.fullpath, 'fullpath should be \"' + expectedParts.fullpath + '\"');
+    });
+  }
 
-test('pathname, fullpath, protocol, hash and search are correct for relative HTTP URLs', function(assert) {
-  testUrl(assert, '/mock/my/request?test=abc#def', {
-    protocol: 'http:',
-    pathname: '/mock/my/request',
-    host: window.location.host,
-    search: '?test=abc',
-    hash: '#def',
-    fullpath: '/mock/my/request?test=abc#def'
+  describe('relative HTTP URLs', function() {
+    testUrl('/mock/my/request?test=abc#def', {
+      protocol: 'http:',
+      pathname: '/mock/my/request',
+      host: window.location.host,
+      search: '?test=abc',
+      hash: '#def',
+      fullpath: '/mock/my/request?test=abc#def'
+    });
+  });
+
+  describe('same-origin absolute HTTP URLs', function() {
+    testUrl(window.location.protocol + '//' + window.location.host + '/mock/my/request?test=abc#def', {
+      protocol: window.location.protocol,
+      pathname: '/mock/my/request',
+      host: window.location.host,
+      search: '?test=abc',
+      hash: '#def',
+      fullpath: '/mock/my/request?test=abc#def'
+    });
+  });
+
+  describe('cross-origin absolute HTTP URLs', function() {
+    testUrl('https://www.yahoo.com/mock/my/request?test=abc', {
+      protocol: 'https:',
+      pathname: '/mock/my/request',
+      host: 'www.yahoo.com',
+      search: '?test=abc',
+      hash: '',
+      fullpath: '/mock/my/request?test=abc'
+    });
   });
 });
 
-test('pathname, fullpath, protocol, hash and search are correct for same-origin absolute HTTP URLs', function(assert) {
-  testUrl(assert, window.location.protocol + '//' + window.location.host + '/mock/my/request?test=abc#def', {
-    protocol: window.location.protocol,
-    pathname: '/mock/my/request',
-    host: window.location.host,
-    search: '?test=abc',
-    hash: '#def',
-    fullpath: '/mock/my/request?test=abc#def'
-  });
-});
-
-test('pathname, fullpath, protocol, hash and search are correct for cross-origin absolute HTTP URLs', function(assert) {
-  testUrl(assert, 'https://www.yahoo.com/mock/my/request?test=abc', {
-    protocol: 'https:',
-    pathname: '/mock/my/request',
-    host: 'www.yahoo.com',
-    search: '?test=abc',
-    hash: '',
-    fullpath: '/mock/my/request?test=abc'
-  });
-});


### PR DESCRIPTION
I've never liked the "a test is in a module if it follows a call to `module`" style QUnit:
  
  * Bumps to newer QUnit for development 
  * Refactors test suite into nested QUnit style
  * Refactors suite to use `beforeEach`/`afterEach` instead of `setup`/`teardown`
  * Removes a bunch of top-level var setting/unsetting 