### PR TITLE
added support for setting responseType to array buffer

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -146,13 +146,18 @@ function interceptor(pretender) {
 
     var xhr = fakeXHR._passthroughRequest = new pretender._nativeXMLHttpRequest();
 
+    if (fakeXHR.responseType === 'arraybuffer') {
+      lifecycleProps = ['readyState', 'response', 'status', 'statusText'];
+      xhr.responseType = fakeXHR.responseType;
+    }
+
     // Use onload if the browser supports it
     if ('onload' in xhr) {
       evts.push('load');
     }
 
     // add progress event for async calls
-    if (fakeXHR.async) {
+    if (fakeXHR.async && fakeXHR.responseType !== 'arraybuffer') {
       evts.push('progress');
     }
 

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -91,6 +91,34 @@ describe('passthrough requests',  function(config) {
     xhr.send('some data');
   });
 
+  asyncTest('asynchronous request with pass-through and ' +
+    'arraybuffer as responseType', function(assert) {
+    var pretender = this.pretender;
+    function testXHR() {
+      this.pretender = pretender;
+      this.open = function() {};
+      this.setRequestHeader = function() {};
+      this.upload = {};
+      this.responseType = '';
+      this.send = {
+        pretender: pretender,
+        apply: function(xhr, argument) {
+          assert.equal(xhr.responseType, 'arraybuffer');
+          this.pretender.resolve(xhr);
+          QUnit.start();
+        }
+      };
+    }
+    pretender._nativeXMLHttpRequest = testXHR;
+
+    pretender.get('/some/path', pretender.passthrough);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('GET', '/some/path');
+    xhr.responseType = 'arraybuffer';
+    xhr.send();
+  });
+
   asyncTest('synchronous request does not have timeout, withCredentials and onprogress event', function(assert) {
     var pretender = this.pretender;
     function testXHR() {


### PR DESCRIPTION
I was having trouble loading binary files when using [Mirage](https://github.com/samselikoff/ember-cli-mirage) in my Ember project. It seems that pretender didn't support other responses than text.

This change allow you to set the contentType of an XHR request to arraybuffer, this results in the binary content being available using the response property. 

```js
var xhr = new XMLHttpRequest();
  xhr.open("GET", '/assets/pretender.ogg', true );
  // important because this allow to load the binary data correctly, it makes the response available which contains the arraybuffer
  xhr.responseType = 'arraybuffer';
  xhr.onload = function ()
  {
   var arrayBuffer = xhr.response;
  };
  xhr.send();
```

this PR fixes #72 