### PR TITLE
Avoid setting `QUnit.module.exports = Pretender`.

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -419,7 +419,7 @@ Pretender.parseURL = parseURL;
 Pretender.Hosts = Hosts;
 Pretender.Registry = Registry;
 
-if (typeof module === 'object') {
+if (typeof module === 'object' && typeof exports !== 'undefined' && module.exports === exports) {
   module.exports = Pretender;
 } else if (typeof define !== 'undefined') {
   define('pretender', [], function() {


### PR DESCRIPTION
When using `QUnit` along with `Pretender`, the UMD style that we were previously using would assign an `.exports` property to the `QUnit.module` method (which is present in QUnit 1.x as `self.module` also). This changes to check that we are actually in a node-like environment (where `exports === module.exports`) before setting `module.exports`.
