### PR TITLE
Add blob support to passthrough

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -146,18 +146,18 @@ function interceptor(pretender) {
 
     var xhr = fakeXHR._passthroughRequest = new pretender._nativeXMLHttpRequest();
 
-    if (fakeXHR.responseType === 'arraybuffer') {
+    if (fakeXHR.responseType === 'arraybuffer' || fakeXHR.responseType === 'blob') {
       lifecycleProps = ['readyState', 'response', 'status', 'statusText'];
       xhr.responseType = fakeXHR.responseType;
     }
 
     // Use onload if the browser supports it
-    if ('onload' in xhr) {
+    if ('onload' in xhr && fakeXHR.responseType !== 'blob') {
       evts.push('load');
     }
 
     // add progress event for async calls
-    if (fakeXHR.async && fakeXHR.responseType !== 'arraybuffer') {
+    if (fakeXHR.async && fakeXHR.responseType !== 'arraybuffer' && fakeXHR.responseType !== 'blob') {
       evts.push('progress');
     }
 

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -119,6 +119,34 @@ describe('passthrough requests',  function(config) {
     xhr.send();
   });
 
+  asyncTest('asynchronous request with pass-through and ' +
+    'blob as responseType', function(assert) {
+    var pretender = this.pretender;
+    function testXHR() {
+      this.pretender = pretender;
+      this.open = function() {};
+      this.setRequestHeader = function() {};
+      this.upload = {};
+      this.responseType = '';
+      this.send = {
+        pretender: pretender,
+        apply: function(xhr, argument) {
+          assert.equal(xhr.responseType, 'blob');
+          this.pretender.resolve(xhr);
+          QUnit.start();
+        }
+      };
+    }
+    pretender._nativeXMLHttpRequest = testXHR;
+
+    pretender.get('/some/path', pretender.passthrough);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('GET', '/some/path');
+    xhr.responseType = 'blob';
+    xhr.send();
+  });
+
   asyncTest('synchronous request does not have timeout, withCredentials and onprogress event', function(assert) {
     var pretender = this.pretender;
     function testXHR() {


### PR DESCRIPTION
We're using blobs for file downloads and these modifications got those XHR requests working through pretender's passthrough.

It's mostly the same as what was done for `arraybuffer`. The main other issue I experienced was that the `onload` event was fired twice. By skipping it in pretender the issue was avoided.