### PR TITLE
Fix for passthrough requests with empty responseText

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -165,7 +165,7 @@ function interceptor(pretender) {
     function copyLifecycleProperties(propertyNames, fromXHR, toXHR) {
       for (var i = 0; i < propertyNames.length; i++) {
         var prop = propertyNames[i];
-        if (fromXHR[prop]) {
+        if (fromXHR.hasOwnProperty(prop)) {
           toXHR[prop] = fromXHR[prop];
         }
       }

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -275,7 +275,37 @@ describe('passthrough requests',  function(config) {
       }
     }
   });
+
+  test('asynchronous request with pass-through and empty response', function(assert) {
+    var done = assert.async();
+    var pretender = this.pretender;
+
+    function testXHR() {
+      this.pretender = pretender;
+      this.open = function() {};
+      this.setRequestHeader = function() {};
+      this.responseText = '';
+      this.onload = true;
+      this.send = {
+        pretender: pretender,
+        apply: function(xhr, argument) {
+          xhr.onload({ target: xhr, type: 'load' });
+        }
+      };
+    }
+    pretender._nativeXMLHttpRequest = testXHR;
+
+    pretender.get('/some/path', pretender.passthrough);
+
+    var xhr = new window.XMLHttpRequest();
+    xhr.open('GET', '/some/path');
+    xhr.addEventListener('load', function _onload(event) {
+      assert.equal(xhr.responseText, event.target.responseText,
+        'responseText for real and fake xhr are both blank strings');
+      done();
+    });
+
+    xhr.send();
+  });
+
 });
-
-
-


### PR DESCRIPTION
There's a somewhat edge case issue we encountered where blank strings returned from the passthrough request weren't being copied on to the fake xhr's responseText property, eg:

``` javascript
// server
app.get('/foo', function() {
  return '';
});

// client
xhr.open('GET', '/foo');
xhr.onload = function() {
  assert(xhr.responseText === ''); // Error (xhr.responseText === null)
}
xhr.send();
```
