### PR TITLE
Update Route Recognizer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "FakeXMLHttpRequest": "^1.4.0",
-    "route-recognizer": "~0.1.1"
+    "route-recognizer": "^0.2.3"
   },
   "devDependencies": {
     "jquery": "~2.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "fake-xml-http-request": "^1.4.0",
-    "route-recognizer": "^0.1.9"
+    "route-recognizer": "^0.2.3"
   },
   "jspm": {
     "shim": {


### PR DESCRIPTION
The ^0.1.0 series is broken beginning after v0.1.5. This updates route-recognizer to a version with more-correct escaping semantics without regressions in specificity handling.