### PR TITLE
Remove onprogress for sync requests

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -139,7 +139,7 @@ function interceptor(pretender) {
     var evts = ['error', 'timeout', 'abort', 'readystatechange'];
 
     // event types to handle on the xhr.upload
-    var uploadEvents = [''];
+    var uploadEvents = [];
 
     // properties to copy from the native xhr to fake xhr
     var lifecycleProps = ['readyState', 'responseText', 'responseXML', 'status', 'statusText'];

--- a/pretender.js
+++ b/pretender.js
@@ -151,12 +151,13 @@ function interceptor(pretender) {
       xhr.responseType = fakeXHR.responseType;
     }
 
-    // Use onload if the browser supports it
+    // use onload if the browser supports it
     if ('onload' in xhr) {
       evts.push('load');
     }
 
     // add progress event for async calls
+    // avoid using progress events for sync calls, they will hang https://bugs.webkit.org/show_bug.cgi?id=40996.
     if (fakeXHR.async && fakeXHR.responseType !== 'arraybuffer') {
       evts.push('progress');
       uploadEvents.push('progress');

--- a/pretender.js
+++ b/pretender.js
@@ -139,7 +139,7 @@ function interceptor(pretender) {
     var evts = ['error', 'timeout', 'abort', 'readystatechange'];
 
     // event types to handle on the xhr.upload
-    var uploadEvents = ['progress'];
+    var uploadEvents = [''];
 
     // properties to copy from the native xhr to fake xhr
     var lifecycleProps = ['readyState', 'responseText', 'responseXML', 'status', 'statusText'];
@@ -159,6 +159,7 @@ function interceptor(pretender) {
     // add progress event for async calls
     if (fakeXHR.async && fakeXHR.responseType !== 'arraybuffer') {
       evts.push('progress');
+      uploadEvents.push('progress');
     }
 
     // update `propertyNames` properties from `fromXHR` to `toXHR`


### PR DESCRIPTION
We've found that sync calls hang with onprogress events, which isn't w3c compliant. Removing these events for sync calls.
