### PR TITLE
Allow user-supplied handler to return a Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ var server = new Pretender(function(){
 });
 ```
 
+Or, optionally, return a Promise.
+
+```javascript
+var server = new Pretender(function() {
+  this.get('/api/songs', function(request) {
+    return new Promise(function(resolve) {
+      var response = [
+        200,
+        {'content-type': 'application/javascript'},
+        '[{"id": 12}, {"id": 14}]'
+      ];
+      resolve(response);
+    });
+  });
+});
+```
+
 ### Pass-Through
 You can specify paths that should be ignored by pretender and made as real XHR requests.
 Enable these by specifying pass-through routes with `pretender.passthrough`:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 // Karma configuration
-// Generated on Sun Apr 27 2014 14:19:31 GMT-0500 (CDT)
+// Generated on Thu Oct 06 2016 14:24:14 GMT+0800 (PHT)
 
 module.exports = function(config) {
   config.set({
@@ -19,6 +19,7 @@ module.exports = function(config) {
       'bower_components/route-recognizer/dist/route-recognizer.js',
       'bower_components/jquery-1/index.js',
       'bower_components/jquery/dist/jquery.js',
+      'node_modules/es6-promise/dist/es6-promise.auto.js',
       'pretender.js',
       'test/**/*.js'
     ],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "bower": "^1.3.5",
     "coveralls": "^2.11.3",
+    "es6-promise": "^4.0.5",
     "jscs": "^2.0.0",
     "jshint": "^2.8.0",
     "karma": "^0.13.8",

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -458,5 +458,28 @@ describe('pretender invoking', function(config) {
     $.ajax({url: url});
     ok(wasCalled);
   });
+
+  it('accepts a handler that returns a promise', function(assert) {
+    var done = assert.async();
+
+    var json = '{foo: "bar"}';
+
+    this.pretender.get('/some/path', function(req) {
+      return new Promise(function(resolve) {
+        resolve([200, {}, json]);
+      });
+    });
+
+    this.pretender.handledRequest = function(verb, path, request) {
+      ok(true, 'handledRequest hook was called');
+      equal(verb, 'GET');
+      equal(path, '/some/path');
+      equal(request.responseText, json);
+      equal(request.status, '200');
+      done();
+    };
+
+    $.ajax({url: '/some/path'});
+  });
 });
 


### PR DESCRIPTION
This implements handling of a thenable in `handleRequest`.  Allows user to return a promise, e.g.:

```js
this.get('/api/song/12', function(request) {
  return new Promise(function(resolve) {
    resolve([ 200, {}, '{"id": 12}' ]);
  });
});
```


Closes #57 