### PR TITLE
Remove node 0.12 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
   - "4.2"
   - "5"
 


### PR DESCRIPTION
Perhaps pulling the trigger a bit early, but we only really support this for running tests and that seems silly for a build about to exit LTS.