### PR TITLE
Add tests for simulating empty body response

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ var server = new Pretender(function() {
 });
 ```
 
+You may return `null` or `undefined` instead of a string body, to simulate real-world responses:
+
+```javascript
+var server = new Pretender(function(){
+  this.get('/photos/:id/mark_favorite', function(request) {
+    return [
+      200,
+      {'content-type': 'application/json'},
+      null
+    ];
+  });
+});
+```
+
 ### Pass-Through
 You can specify paths that should be ignored by pretender and made as real XHR requests.
 Enable these by specifying pass-through routes with `pretender.passthrough`:

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -481,5 +481,34 @@ describe('pretender invoking', function(config) {
 
     $.ajax({url: '/some/path'});
   });
-});
 
+  it('can return a null body response', function(assert) {
+    var done = assert.async();
+
+    this.pretender.get('/some/path', function(req) {
+      return [200, {'Content-Type': 'application/json'}, null];
+    });
+
+    this.pretender.handledRequest = function(verb, path, request) {
+      equal(request.responseText, '');
+      done();
+    };
+
+    $.ajax({url: '/some/path'});
+  });
+
+  it('can return an undefined body response', function(assert) {
+    var done = assert.async();
+
+    this.pretender.get('/some/path', function(req) {
+      return [200, {'Content-Type': 'application/json'}, undefined];
+    });
+
+    this.pretender.handledRequest = function(verb, path, request) {
+      equal(request.responseText, '');
+      done();
+    };
+
+    $.ajax({url: '/some/path'});
+  });
+});


### PR DESCRIPTION
For issue #123 - it appears that null and undefined body responses are already handled OK by pretender. I've added tests for this, and an extra line in the README per the issue comments.