### PR TITLE
Support running pretender in node with jsdom

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -3,7 +3,8 @@
 
 var appearsBrowserified = typeof self !== 'undefined' &&
                           typeof process !== 'undefined' &&
-                          Object.prototype.toString.call(process) === '[object Object]';
+                          (Object.prototype.toString.call(process) === '[object Object]' ||
+                           Object.prototype.toString.call(process) === '[object process]');
 
 var RouteRecognizer = appearsBrowserified ? require('route-recognizer') : self.RouteRecognizer;
 var FakeXMLHttpRequest = appearsBrowserified ? require('fake-xml-http-request') : self.FakeXMLHttpRequest;


### PR DESCRIPTION
Testing `Object.prototype.toString.call(process)` in several versions of node (back to `0.12.18`) I always saw it equal `[object process]`, not `[object Object]`. This is all that's preventing me from running my integration suite in node using `jsdom`.

Fixes #152 
Fixes #191 