### PR TITLE
Enable Abortable fetch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "./pretender.js"
   ],
   "dependencies": {
-    "FakeXMLHttpRequest": "https://github.com/raido/FakeXMLHttpRequest.git#cb05658",
+    "FakeXMLHttpRequest": "^2.0.1",
     "route-recognizer": "^0.2.3"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "./pretender.js"
   ],
   "dependencies": {
-    "FakeXMLHttpRequest": "^1.6.0",
+    "FakeXMLHttpRequest": "https://github.com/raido/FakeXMLHttpRequest.git#cb05658",
     "route-recognizer": "^0.2.3"
   },
   "devDependencies": {

--- a/test/fetch_test.js
+++ b/test/fetch_test.js
@@ -63,37 +63,7 @@ describe('pretender invoking by fetch', function(config) {
     return wait;
   });
 
-
-  // TODO: Pretender doesn't work with abortable fetch
-  // src in fake_xml_http_request.js
-  // ```
-  // abort: function abort() {
-  //   this.aborted = true;
-  //   this.responseText = null;
-  //   this.errorFlag = true;
-  //   this.requestHeaders = {};
-
-  //   if (this.readyState > FakeXMLHttpRequest.UNSENT && this.sendFlag) {
-  //     this._readyStateChange(FakeXMLHttpRequest.DONE);
-  //     this.sendFlag = false;
-  //   }
-
-  //   this.readyState = FakeXMLHttpRequest.UNSENT;
-
-  //   this.dispatchEvent(new _Event("abort", false, false, this));
-  //   if (typeof this.onerror === "function") {
-  //       this.onerror();
-  //   }
-  // }
-  // ```
-  // For `fake_xml_http_request` impl, the request is resolved once its state
-  // is changed to `DONE` so the `reject` is not cathed.
-  // So the senario happens in pretender is:
-  // 1. state chagne to `DONE`, trigger resolve request
-  // 2. abort, trigger reject
-  // 3. xhr.onerror, trigger reject
-  // The first resolve wins, error thus not rejected but an empty request is resolved.
-  it('has NO Abortable fetch', function(assert) {
+  it('has Abortable fetch', function(assert) {
     assert.expect(1);
     this.pretender.get(
       '/downloads',
@@ -110,8 +80,8 @@ describe('pretender invoking by fetch', function(config) {
     }, 10);
 
     return fetch('/downloads', { signal: signal })
-      .then(function(data) {
-        assert.ok(data, 'AbortError was not rejected');
+      .catch(function(err) {
+        assert.equal(err.name, 'AbortError');
       });
   });
 });


### PR DESCRIPTION
Once XMLHttpRequest PR is accepted, this needs version bump in bower.json.

https://github.com/pretenderjs/FakeXMLHttpRequest/issues/41
https://github.com/pretenderjs/FakeXMLHttpRequest/pull/42

@stefanpenner 