### PR TITLE
Export Pretender in a way Typescript understands

### DIFF
--- a/pretender.js
+++ b/pretender.js
@@ -497,7 +497,7 @@ Pretender.Hosts = Hosts;
 Pretender.Registry = Registry;
 
 if (typeof module === 'object') {
-  module.exports = Pretender;
+  module.exports.default = Pretender;
 } else if (typeof define !== 'undefined') {
   define('pretender', [], function() {
     return Pretender;


### PR DESCRIPTION
Fixes #229 

- [x] Test in TS environment
- [x] run test suite to ensure the rest is working
- [ ] get feedback from people who know commonjs to find out if this breaks other things (please comment below)

This patch fixes my issue, so I am happy with it. I do not know if changing `module.exports` to `module.exports.default` has consequences for others.