### PR TITLE
Expose a way to passthrough after the request is found to be unhandled

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,35 @@ In some case, you will need to force pretender to passthough, just start your se
 const server = new Pretender({ forcePassthrough: true })
 ```
 
+Other times, you may want to decide whether or not to passthrough when the call is made. In that
+case you can use the `.passthrough()` function on the fake request itself. (The [`unhandledRequest`
+property is discussed below](#unhandled-requests).)
+
+```javascript
+server.unhandledRequest = function(verb, path, request) {
+  if (myIgnoreRequestChecker(path)) {
+    console.warn(`Ignoring request) ${verb.toUpperCase()} : ${path}`);
+  } else {
+    console.warn(
+      `Unhandled ${verb.toUpperCase()} : ${path} >> Passing along. See eventual response below.`
+    )
+  
+    const xhr = request.passthrough(); // <-- A native, sent xhr is returned
+  
+    xhr.onloadend = (ev) => {
+        console.warn(`Response for ${path}`, {
+          verb,
+          path,
+          request,
+          responseEvent: ev,
+        })
+      };
+  }
+};
+```
+
+The `.passthrough()` function will immediately create, send, and return a native `XMLHttpRequest`.
+
 ### Timing Parameter
 The timing parameter is used to control when a request responds. By default, a request responds
 asynchronously on the next frame of the browser's event loop. A request can also be configured to respond


### PR DESCRIPTION
This PR aims to allow a request to be passed-through in the `unhandledRequests` hook.

Totally fine to say that you don't want this feature. I am adding it for me, but since it was simple, I figured add PR you here.

This allows you to actually pass certain unhandled requests through at runtime if you so choose. Sam Selikoff offered this as an example of a feature this unlocks (better than my original example). Currently, you can't really simply declare multiple multiple domains as a passthrough. You'd need something like:

```js
this.get('api1.something.com', this.passthrough)
this.get('api2.something.com', this.passthrough)
// etc
```

This feature addition allows you to handle all of them with any runtime check you'd like to implement:

```js
server.unhandledRequest = function(verb, path, request) {
  if (path.startsWith('aws')) {
    request.passthrough() // <-- This is what is now possible
  }
}
```

- [x] Add a `.passthrough()` method to the FakeRequest
- [x] Add tests.
- [x] Add documentation.