### PR TITLE
Fix a typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $.get('/photos/12', {success() => { ... }})
 ## Usage
 
 ```
-yard add -D pretender
+yarn add -D pretender
 # or
 npm install --save-dev pretender
 ```


### PR DESCRIPTION
This change is to fix a typo in the README.md.

yard add -D pretender -> yarn add -D pretender