### PR TITLE
bugfix: iife is 100% backwards compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ bower_components
 node_modules
 coverage*
 dist
-dist/pretender.es.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ bower_components
 node_modules
 coverage*
 dist
-src/pretender.es.js
+dist/pretender.es.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-src
-test
-rollup.config.js
-karma.conf.js
-*.md
-yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-src/index.ts
+src
 test
 rollup.config.js
 karma.conf.js

--- a/iife-wrapper.js
+++ b/iife-wrapper.js
@@ -1,0 +1,37 @@
+var Pretender = (function(self) {
+  function getModuleDefault(module) {
+    return module.default || module;
+  }
+
+  var appearsBrowserified =
+    typeof self !== 'undefined' &&
+    typeof process !== 'undefined' &&
+    (Object.prototype.toString.call(process) === '[object Object]' ||
+      Object.prototype.toString.call(process) === '[object process]');
+
+  var RouteRecognizer = appearsBrowserified
+    ? getModuleDefault(require('route-recognizer'))
+    : self.RouteRecognizer;
+  var FakeXMLHttpRequest = appearsBrowserified
+    ? getModuleDefault(require('fake-xml-http-request'))
+    : self.FakeXMLHttpRequest;
+
+  // fetch related ponyfills
+  var FakeFetch = appearsBrowserified
+    ? getModuleDefault(require('whatwg-fetch'))
+    : self.WHATWGFetch;
+
+  /*==ROLLUP_CONTENT==*/
+
+  if (typeof module === 'object') {
+    module.exports = Pretender;
+  } else if (typeof define !== 'undefined') {
+    define('pretender', [], function() {
+      return Pretender;
+    });
+  }
+
+  self.Pretender = Pretender;
+
+  return Pretender;
+})(self);

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
     "route-recognizer": "^0.3.3",
     "whatwg-fetch": "^3.0.0"
   },
+  "files": [
+    "dist",
+    "index.d.ts"
+  ],
   "jspm": {
     "shim": {
       "pretender": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pretender",
   "version": "2.1.0",
   "main": "./dist/pretender.js",
-  "module": "./src/pretender.es.js",
+  "module": "./dist/pretender.es.js",
   "types": "index.d.ts",
   "description": "Pretender is a mock server library for XMLHttpRequest and Fetch, that comes with an express/sinatra style syntax for defining routes and their handlers.",
   "license": "MIT",
@@ -40,7 +40,7 @@
     "karma-sinon": "^1.0.5",
     "phantomjs": "^2.1.7",
     "qunit": "^2.6.1",
-    "rollup": "0.68.2",
+    "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-multi-entry": "^2.1.0",
     "rollup-plugin-node-resolve": "^4.0.0",
@@ -50,9 +50,9 @@
     "typescript": "~3.1.1"
   },
   "dependencies": {
-    "whatwg-fetch": "^3.0.0",
     "fake-xml-http-request": "^2.0.0",
-    "route-recognizer": "^0.3.3"
+    "route-recognizer": "^0.3.3",
+    "whatwg-fetch": "^3.0.0"
   },
   "jspm": {
     "shim": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,49 +2,15 @@ const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 const typescript = require('rollup-plugin-typescript');
 const pkg = require('./package.json');
-
+const fs = require('fs');
 const globals = {
   'whatwg-fetch': 'FakeFetch',
   'fake-xml-http-request': 'FakeXMLHttpRequest',
-  'route-recognizer': 'RouteRecognizer',
+  'route-recognizer': 'RouteRecognizer'
 };
 
-const iife = {
-  banner:
-`var Pretender = (function (self) {
-
-  function getModuleDefault(module) {
-    return module.default || module;	
-  }
-
-  var appearsBrowserified = typeof self !== 'undefined' &&
-                            typeof process !== 'undefined' &&
-                            (Object.prototype.toString.call(process) === '[object Object]' ||
-                             Object.prototype.toString.call(process) === '[object process]');
-
-  var RouteRecognizer = appearsBrowserified ? getModuleDefault(require('route-recognizer')) : self.RouteRecognizer;
-  var FakeXMLHttpRequest = appearsBrowserified ? getModuleDefault(require('fake-xml-http-request')) :
-    self.FakeXMLHttpRequest;
-
-  // fetch related ponyfills
-  var FakeFetch = appearsBrowserified ? getModuleDefault(require('whatwg-fetch')) : self.WHATWGFetch;
-`,
-  footer:
-`
-if (typeof module === 'object') {
-  module.exports = Pretender;	
-} else if (typeof define !== 'undefined') {	
-  define('pretender', [], function() {	
-    return Pretender;	
-  });
-}
-
-self.Pretender = Pretender;
-
-return Pretender;
-
-}(self));`,
-};
+const rollupTemplate = fs.readFileSync('./iife-wrapper.js').toString();
+const [ banner, footer ] = rollupTemplate.split('/*==ROLLUP_CONTENT==*/');
 
 module.exports = {
   input: 'src/index.ts',
@@ -54,18 +20,14 @@ module.exports = {
       name: 'Pretender',
       file: pkg.main,
       format: 'iife',
-      globals: globals,
-      banner: iife.banner,
-      footer: iife.footer,
+      globals,
+      banner,
+      footer
     },
     {
       file: pkg.module,
-      format: 'es',
-    },
+      format: 'es'
+    }
   ],
-  plugins: [
-    commonjs(),
-    resolve(),
-    typescript()
-  ],
+  plugins: [commonjs(), resolve(), typescript()]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,37 +1,66 @@
 const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
 const resolve = require('rollup-plugin-node-resolve');
 const typescript = require('rollup-plugin-typescript');
 const pkg = require('./package.json');
 
-const selfId = path.resolve(__dirname, 'src/iife-self-placeholder.js');
+const globals = {
+  'whatwg-fetch': 'FakeFetch',
+  'fake-xml-http-request': 'FakeXMLHttpRequest',
+  'route-recognizer': 'RouteRecognizer',
+};
+
+const iife = {
+  banner:
+`var Pretender = (function (self) {
+
+  function getModuleDefault(module) {
+    return module.default || module;	
+  }
+
+  var appearsBrowserified = typeof self !== 'undefined' &&
+                            typeof process !== 'undefined' &&
+                            (Object.prototype.toString.call(process) === '[object Object]' ||
+                             Object.prototype.toString.call(process) === '[object process]');
+
+  var RouteRecognizer = appearsBrowserified ? getModuleDefault(require('route-recognizer')) : self.RouteRecognizer;
+  var FakeXMLHttpRequest = appearsBrowserified ? getModuleDefault(require('fake-xml-http-request')) :
+    self.FakeXMLHttpRequest;
+
+  // fetch related ponyfills
+  var FakeFetch = appearsBrowserified ? getModuleDefault(require('whatwg-fetch')) : self.WHATWGFetch;
+`,
+  footer:
+`
+if (typeof module === 'object') {
+  module.exports = Pretender;	
+} else if (typeof define !== 'undefined') {	
+  define('pretender', [], function() {	
+    return Pretender;	
+  });
+}
+
+self.Pretender = Pretender;
+
+return Pretender;
+
+}(self));`,
+};
 
 module.exports = {
   input: 'src/index.ts',
-  external: [
-    selfId,
-    'whatwg-fetch',
-    'fake-xml-http-request',
-    'route-recognizer',
-  ],
+  external: Object.keys(pkg.dependencies),
   output: [
     {
       name: 'Pretender',
       file: pkg.main,
       format: 'iife',
-      globals: {
-        [selfId]: 'self',
-        'whatwg-fetch': 'FakeFetch',
-        'fake-xml-http-request': 'FakeXMLHttpRequest',
-        'route-recognizer': 'RouteRecognizer',
-      },
-      banner: 'var FakeFetch = self.WHATWGFetch;\n' +
-              'var FakeXMLHttpRequest = self.FakeXMLHttpRequest;\n' +
-              'var RouteRecognizer = self.RouteRecognizer;\n',
+      globals: globals,
+      banner: iife.banner,
+      footer: iife.footer,
     },
     {
       file: pkg.module,
-      format: 'es'
+      format: 'es',
     },
   ],
   plugins: [

--- a/src/iife-self-placeholder.js
+++ b/src/iife-self-placeholder.js
@@ -1,3 +1,0 @@
-// This is just a placeholder for the build step
-// See the IIFE output in the Rollup config
-export default window;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import self from './iife-self-placeholder';
 import RouteRecognizer from 'route-recognizer';
 import FakeXMLHttpRequest from 'fake-xml-http-request';
 import * as FakeFetch from 'whatwg-fetch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,11 @@ accepts@1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
+acorn@^6.0.5:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
+  integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
+
 after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
@@ -3769,13 +3774,14 @@ rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.3.3:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-rollup@0.68.2:
-  version "0.68.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.68.2.tgz#c26afb5d981ca7a1a32f76087dbde9dad4fcc653"
-  integrity sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==
+rollup@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.1.2.tgz#8d094b85683b810d0c05a16bd7618cf70d48eba7"
+  integrity sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"
+    acorn "^6.0.5"
 
 route-recognizer@^0.3.3:
   version "0.3.4"


### PR DESCRIPTION
 - [x] ember-cli-pretender can be bumped with no code changes https://github.com/rwjblue/ember-cli-pretender/pull/70
 - [x] ember-cli-mirage can ditch the shim and use the ES6 output https://github.com/samselikoff/ember-cli-mirage/pull/1503