### PR TITLE
Fix passthrough type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ interface SetupConfig {
 }
 export type Config = SetupCallback | SetupConfig;
 export class Server {
-  public passthrough: RequestHandler;
+  public passthrough: ResponseHandler;
 
   constructor(config?: Config);
   // HTTP request verbs


### PR DESCRIPTION
`passthrough` is supposed to be a `ResponseHandler` as 2nd arg of `ResponseHandler`.

```
const server = new Pretender(function() {
  this.get('/photos/:id', this.passthrough);
});
```