### PR TITLE
use `url-parse` package as parsing fallback

### DIFF
--- a/iife-wrapper.js
+++ b/iife-wrapper.js
@@ -15,6 +15,9 @@ var Pretender = (function(self) {
   var FakeXMLHttpRequest = appearsBrowserified
     ? getModuleDefault(require('fake-xml-http-request'))
     : self.FakeXMLHttpRequest;
+  var ParsedUrl = appearsBrowserified
+    ? getModuleDefault(require('url-parse'))
+    : self.ParsedUrl;
 
   // fetch related ponyfills
   var FakeFetch = appearsBrowserified

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "fake-xml-http-request": "^2.0.0",
     "route-recognizer": "^0.3.3",
+    "url-parse": "^1.4.7",
     "whatwg-fetch": "^3.0.0"
   },
   "files": [
@@ -65,7 +66,8 @@
         "deps": [
           "route-recognizer",
           "fake-xml-http-request",
-          "whatwg-fetch"
+          "whatwg-fetch",
+          "url-parse"
         ],
         "exports": "Pretender"
       }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,15 +6,16 @@ const fs = require('fs');
 const globals = {
   'whatwg-fetch': 'FakeFetch',
   'fake-xml-http-request': 'FakeXMLHttpRequest',
-  'route-recognizer': 'RouteRecognizer'
+  'route-recognizer': 'RouteRecognizer',
+  'url-parse': 'ParsedUrl'
 };
 
 const rollupTemplate = fs.readFileSync('./iife-wrapper.js').toString();
 const [ banner, footer ] = rollupTemplate.split('/*==ROLLUP_CONTENT==*/');
-
 module.exports = {
   input: 'src/index.ts',
-  external: Object.keys(pkg.dependencies),
+  // don't exclude url-parse because it does *not* provide a UMD bundle and needs to be included
+  external: Object.keys(pkg.dependencies).filter(x => x !== 'url-parse'),
   output: [
     {
       name: 'Pretender',

--- a/src/parse-url.ts
+++ b/src/parse-url.ts
@@ -1,3 +1,5 @@
+import { default as ParsedUrl } from 'url-parse';
+
 /**
  * parseURL - decompose a URL into its parts
  * @param  {String} url a URL
@@ -16,32 +18,30 @@
  * }
  */
 export default function parseURL(url: string) {
-  // TODO: something for when document isn't present... #yolo
-  var anchor = document.createElement('a');
-  anchor.href = url;
+  var parsedUrl = new ParsedUrl(url);
 
-  if (!anchor.host) {
+  if (!parsedUrl.host) {
     // eslint-disable-next-line no-self-assign
-    anchor.href = anchor.href; // IE: load the host and protocol
+    parsedUrl.href = parsedUrl.href; // IE: load the host and protocol
   }
 
-  var pathname = anchor.pathname;
+  var pathname = parsedUrl.pathname;
   if (pathname.charAt(0) !== '/') {
     pathname = '/' + pathname; // IE: prepend leading slash
   }
 
-  var host = anchor.host;
-  if (anchor.port === '80' || anchor.port === '443') {
-    host = anchor.hostname; // IE: remove default port
+  var host = parsedUrl.host;
+  if (parsedUrl.port === '80' || parsedUrl.port === '443') {
+    host = parsedUrl.hostname; // IE: remove default port
   }
 
   return {
     host: host,
-    protocol: anchor.protocol,
-    search: anchor.search,
-    hash: anchor.hash,
-    href: anchor.href,
+    protocol: parsedUrl.protocol,
+    search: parsedUrl.query,
+    hash: parsedUrl.hash,
+    href: parsedUrl.href,
     pathname: pathname,
-    fullpath: pathname + (anchor.search || '') + (anchor.hash || '')
+    fullpath: pathname + (parsedUrl.query || '') + (parsedUrl.hash || '')
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,11 @@ qs@~6.3.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
   integrity sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
 
+querystringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
+  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
 qunit@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.8.0.tgz#007474727cdba323c35f9526e21c0687f8ea04b3"
@@ -4609,6 +4614,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Same as #219, hoping to get pretender working with React Native projects that don't have `document.createElement` available for URL parsing. `url-parse` has a minimal minimal footprint and this won't affect other consumers. That said, I'm happy to rework it to not use `document.createElement` at all and rely only on `url-parse` for consistency.

As for the `self` reference that #219 offered, I've found that it's common for RN projects using browser-y libraries to use [react-native-browser-polyfill](https://github.com/johanneslumpe/react-native-browser-polyfill) to achieve something similar, so changes aren't necessary here. Otherwise, I can pull in the [suggestion](https://github.com/pretenderjs/pretender/pull/219#discussion_r151718023) provided in #219 if that's preferred. 

Thanks : D