### PR TITLE
fix: progress event expects byte size not time

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,30 @@ means the route will use the default behavior.
 When the time is right, you can set `externalState` to `"OH NO DOS ATTACK"` which will make all
 future requests take 15 seconds to respond.
 
+#### Scheduling ProgressEvent
+If the timing parameter is resolved as async, then a [`ProgressEvent`](https://xhr.spec.whatwg.org/#interface-progressevent)
+will be scheduled every 50ms until the reqeust has a respond or is aborted.
+
+To listen to the progress, you can define `onprogress` on the `XMLHttpRequest` object or
+its [`upload` attribute](https://xhr.spec.whatwg.org/#the-upload-attribute).
+
+```javascript
+let xhr = new window.XMLHttpRequest();
+xhr.open('POST', '/uploads');
+// https://fetch.spec.whatwg.org/#concept-request-body
+// https://xhr.spec.whatwg.org/#the-send()-method
+let postBody = new ArrayBuffer(8);
+xhr.upload.onprogress = function(event) {
+  // event.lengthComputable === true
+  // event.total === 8
+  // event.loaded will be incremented every ~50ms
+};
+xhr.onprogress = function(event) {
+  // xhr onprogress will also be triggered
+};
+xhr.send(postBody);
+```
+
 ## Sharing routes
 You can call `map` multiple times on a Pretender instance. This is a great way to share and reuse
 sets of routes between tests:

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,9 +227,21 @@ function verbify(verb) {
 function scheduleProgressEvent(request, startTime, totalTime) {
   setTimeout(function() {
     if (!request.aborted && !request.status) {
-      var ellapsedTime = new Date().getTime() - startTime.getTime();
-      request.upload._progress(true, ellapsedTime, totalTime);
-      request._progress(true, ellapsedTime, totalTime);
+      var elapsedTime = new Date().getTime() - startTime.getTime();
+      var progressTotal;
+      var body = request.requestBody;
+      if (!body) {
+        progressTotal = 0;
+      } else {
+        // Support Blob, BufferSource, USVString, ArrayBufferView
+        progressTotal = body.byteLength || body.size || body.length || 0;
+      }
+      var progressTransmitted =
+        totalTime <= 0 ? 0 : (elapsedTime / totalTime) * progressTotal;
+      // ProgressEvent expects loaded, total
+      // https://xhr.spec.whatwg.org/#interface-progressevent
+      request.upload._progress(true, progressTransmitted, progressTotal);
+      request._progress(true, progressTransmitted, progressTotal);
       scheduleProgressEvent(request, startTime, totalTime);
     }
   }, 50);


### PR DESCRIPTION
Spec: 
- https://xhr.spec.whatwg.org/#the-send()-method
- https://xhr.spec.whatwg.org/#concept-event-fire-progress

fix #274 , supersedes #275 
cc @seanjohnson08 @mike-north 

---
TODO:
- [x] all existing tests continue to pass
- [x] we write a new test that would have _failed_ before this code change, and _now passes_ due to the alteration of how the progress events are handled
- [ ] we include great documentation around "handling uploads with Pretender"