### PR TITLE
Add missing type definitions in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,16 @@ export class Server {
   public head: RequestHandler;
 
   public shutdown(): void;
+
+  public map(maps: Function): void;
+
+  public handledRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
+  public undhandledRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
+  public passtroughRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
+  public erroredRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData, error: Error): void;
+
+  public prepareBody(body: string): string;
+  public prepareHeaders(headers: {[k: string]: string}): {[k: string]: string};
 }
 
 export type RequestHandler = (


### PR DESCRIPTION
This adds some of the missing type definitions in index.d.ts. I tried creating the declaration
using tsc but apparently another rollup-typescript plugin is necessary for this to work and I wasn't
able to generate a useful declarations file with it, so I added it manually. Fixes #277