### PR TITLE
fix: remove node engine constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "8"
-  - "10"
-  - "11"
+  - "12"
 
 before_install:
   - "npm config set spin false"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "types": "index.d.ts",
   "description": "Pretender is a mock server library for XMLHttpRequest and Fetch, that comes with an express/sinatra style syntax for defining routes and their handlers.",
   "license": "MIT",
-  "engines": {
-    "node": "6.* || 8.* || 10.* || >= 11.*"
-  },
   "scripts": {
     "prepublishOnly": "npm run build && npm run tests-only",
     "pretest": "bower install",


### PR DESCRIPTION
Pretender does not support node at all.

Context: https://github.com/rwjblue/ember-cli-pretender/pull/70#issuecomment-549540587