### PR TITLE
Adds url parse and removes the usage of anchor

### DIFF
--- a/iife-wrapper.js
+++ b/iife-wrapper.js
@@ -15,6 +15,9 @@ var Pretender = (function(self) {
   var FakeXMLHttpRequest = appearsBrowserified
     ? getModuleDefault(require('fake-xml-http-request'))
     : self.FakeXMLHttpRequest;
+  var urlParse = appearsBrowserified
+    ? getModuleDefault(require('url-parse'))
+    : self.urlParse;
 
   // fetch related ponyfills
   var FakeFetch = appearsBrowserified

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "sinon": "^3.2.1",
     "tslib": "^1.9.3",
     "typescript": "~3.1.1",
-    "typescript-eslint-parser": "^21.0.2"
+    "typescript-eslint-parser": "^21.0.2",
+    "url-parse": "^1.4.7"
   },
   "dependencies": {
     "fake-xml-http-request": "^2.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,11 +6,12 @@ const fs = require('fs');
 const globals = {
   'whatwg-fetch': 'FakeFetch',
   'fake-xml-http-request': 'FakeXMLHttpRequest',
-  'route-recognizer': 'RouteRecognizer'
+  'route-recognizer': 'RouteRecognizer',
+  'url-parse': 'urlParse'
 };
 
 const rollupTemplate = fs.readFileSync('./iife-wrapper.js').toString();
-const [ banner, footer ] = rollupTemplate.split('/*==ROLLUP_CONTENT==*/');
+const [banner, footer] = rollupTemplate.split('/*==ROLLUP_CONTENT==*/');
 
 module.exports = {
   input: 'src/index.ts',

--- a/src/parse-url.ts
+++ b/src/parse-url.ts
@@ -1,3 +1,4 @@
+import urlParse from 'url-parse';
 /**
  * parseURL - decompose a URL into its parts
  * @param  {String} url a URL
@@ -16,32 +17,30 @@
  * }
  */
 export default function parseURL(url: string) {
-  // TODO: something for when document isn't present... #yolo
-  var anchor = document.createElement('a');
-  anchor.href = url;
+  let parsedUrl = new urlParse(url);
 
-  if (!anchor.host) {
+  if (!parsedUrl.host) {
     // eslint-disable-next-line no-self-assign
-    anchor.href = anchor.href; // IE: load the host and protocol
+    parsedUrl.href = parsedUrl.href; // IE: load the host and protocol
   }
 
-  var pathname = anchor.pathname;
+  var pathname = parsedUrl.pathname;
   if (pathname.charAt(0) !== '/') {
     pathname = '/' + pathname; // IE: prepend leading slash
   }
 
-  var host = anchor.host;
-  if (anchor.port === '80' || anchor.port === '443') {
-    host = anchor.hostname; // IE: remove default port
+  var host = parsedUrl.host;
+  if (parsedUrl.port === '80' || parsedUrl.port === '443') {
+    host = parsedUrl.hostname; // IE: remove default port
   }
 
   return {
     host: host,
-    protocol: anchor.protocol,
-    search: anchor.search,
-    hash: anchor.hash,
-    href: anchor.href,
+    protocol: parsedUrl.protocol,
+    search: parsedUrl.query,
+    hash: parsedUrl.hash,
+    href: parsedUrl.href,
     pathname: pathname,
-    fullpath: pathname + (anchor.search || '') + (anchor.hash || '')
+    fullpath: pathname + (parsedUrl.query || '') + (parsedUrl.hash || '')
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3399,6 +3399,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+querystringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
+  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
 qunit@^2.6.1:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.9.3.tgz#9522a088e76f0782f70a45db92f2fd14db311bcc"
@@ -4491,6 +4496,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## What changed and why
This PR replaces the usage of `document` to parse a URL with the library [`url-parse`](https://github.com/unshiftio/url-parse). By doing this Pretender can be used in environments that don't include the DOM such as React Native.

The work done here is based on this PR https://github.com/pretenderjs/pretender/pull/267. Additionally I added a couple of fixes that @xg-wang requested.

The only review comments that are pending from the old PR are the following:
https://github.com/pretenderjs/pretender/pull/267#discussion_r324433409
https://github.com/pretenderjs/pretender/pull/267#discussion_r324433457

To solve the pending issues I originally thought of using the Karma launcher for IE but that won't work on a IE environment because we won't have an IE binary. I was thinking that we could use SauceLabs or BrowserStack to run the tests on different browsers.

I would appreciate it if @xg-wang or @samselikoff  would share their thoughts on how the IE issue could be solved. If we decide to go with SauceLabs we can request an [Open Source Account](https://saucelabs.com/open-sauce).