### PR TITLE
Removes unnecessary url-parse required from iife-wrapper

### DIFF
--- a/iife-wrapper.js
+++ b/iife-wrapper.js
@@ -15,9 +15,6 @@ var Pretender = (function(self) {
   var FakeXMLHttpRequest = appearsBrowserified
     ? getModuleDefault(require('fake-xml-http-request'))
     : self.FakeXMLHttpRequest;
-  var urlParse = appearsBrowserified
-    ? getModuleDefault(require('url-parse'))
-    : self.urlParse;
 
   // fetch related ponyfills
   var FakeFetch = appearsBrowserified


### PR DESCRIPTION
This PR removes an unnecessary import to `url-parse` that I made on the `iife-wrapper`. This import is not needed because we are already bundling `url-parse` with Pretender.

I noticed this issue because it was causing trouble with the tests that Mirage is running.
https://github.com/miragejs/miragejs/pull/312

I verified this fix by installing Pretender on a fork that I have for Mirage and running Mirage's test suite locally. Everything seems to be working correctly now.

cc: @samselikoff 