### PR TITLE
fix: passThroughRequest typo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export class Server {
 
   public handledRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
   public unhandledRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
-  public passtroughRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
+  public passthroughRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData): void;
   public erroredRequest(verb: string, path: string, request: FakeXMLHttpRequest & ExtraRequestData, error: Error): void;
 
   public prepareBody(body: string): string;


### PR DESCRIPTION
Caught this while trying to figure out why the `handledRequests` property isn't exposed on the server type definition.