### PR TITLE
Handle progress events for FormData request body properly

### DIFF
--- a/src/pretender.ts
+++ b/src/pretender.ts
@@ -25,32 +25,36 @@ class NoopArray {
 }
 
 function scheduleProgressEvent(request, startTime, totalTime) {
+  let totalSize = 0;
+  const body = request.requestBody;
+  if (body) {
+    if (body instanceof FormData) {
+      body.forEach((value) => {
+        if (value instanceof File) {
+          totalSize += value.size;
+        } else {
+          totalSize += value.length;
+        }
+      });
+    } else {
+      // Support Blob, BufferSource, USVString, ArrayBufferView
+      totalSize = body.byteLength || body.size || body.length || 0;
+    }
+  }
   setTimeout(function () {
     if (!request.aborted && !request.status) {
       let elapsedTime = new Date().getTime() - startTime.getTime();
-      let progressTotal = 0;
-      let body = request.requestBody;
-      if (body) {
-        if (body instanceof FormData) {
-          body.forEach((value) => {
-            if (value instanceof File) {
-              progressTotal += value.size;
-            } else {
-              progressTotal += value.length;
-            }
-          });
-        } else {
-          // Support Blob, BufferSource, USVString, ArrayBufferView
-          progressTotal = body.byteLength || body.size || body.length || 0;
-        }
-      }
       let progressTransmitted =
-        totalTime <= 0 ? 0 : (elapsedTime / totalTime) * progressTotal;
+        totalTime <= 0 ? 0 : (elapsedTime / totalTime) * totalSize;
       // ProgressEvent expects loaded, total
       // https://xhr.spec.whatwg.org/#interface-progressevent
-      request.upload._progress(true, progressTransmitted, progressTotal);
-      request._progress(true, progressTransmitted, progressTotal);
+      request.upload._progress(true, progressTransmitted, totalSize);
+      request._progress(true, progressTransmitted, totalSize);
       scheduleProgressEvent(request, startTime, totalTime);
+    } else if (request.status) {
+      // we're done, send a final progress event with loaded === total
+      request.upload._progress(true, totalSize, totalSize);
+      request._progress(true, totalSize, totalSize);
     }
   }, 50);
 }

--- a/src/pretender.ts
+++ b/src/pretender.ts
@@ -28,13 +28,21 @@ function scheduleProgressEvent(request, startTime, totalTime) {
   setTimeout(function () {
     if (!request.aborted && !request.status) {
       let elapsedTime = new Date().getTime() - startTime.getTime();
-      let progressTotal;
+      let progressTotal = 0;
       let body = request.requestBody;
-      if (!body) {
-        progressTotal = 0;
-      } else {
-        // Support Blob, BufferSource, USVString, ArrayBufferView
-        progressTotal = body.byteLength || body.size || body.length || 0;
+      if (body) {
+        if (body instanceof FormData) {
+          body.forEach((value) => {
+            if (value instanceof File) {
+              progressTotal += value.size;
+            } else {
+              progressTotal += value.length;
+            }
+          });
+        } else {
+          // Support Blob, BufferSource, USVString, ArrayBufferView
+          progressTotal = body.byteLength || body.size || body.length || 0;
+        }
       }
       let progressTransmitted =
         totalTime <= 0 ? 0 : (elapsedTime / totalTime) * progressTotal;

--- a/test/calling_test.js
+++ b/test/calling_test.js
@@ -466,9 +466,10 @@ describe('pretender invoking', function(config) {
     clock.tick(510);
     assert.equal(
       progressEventCount,
-      4,
+      5,
       'No `onprogress` events are fired after the the request finalizes'
     );
+    assert.equal(lastLoaded, totalSize, 'Final progress event should match total body size');
   });
 
   it('`onprogress` upload events don\'t keep firing once the request has ended', function(
@@ -495,14 +496,16 @@ describe('pretender invoking', function(config) {
       assert.ok(loaded > lastLoaded, 'making progress');
       assert.ok(loaded <= total, 'loaded should always not exceed total');
       progressEventCount++;
+      lastLoaded = loaded;
     };
     xhr.send(postBody);
     clock.tick(510);
     assert.equal(
       progressEventCount,
-      4,
+      5,
       'No `onprogress` events are fired after the the request finalizes'
     );
+    assert.equal(lastLoaded, postBody.size, 'Final progress event should match total body size');
   });
 
   it('no progress upload events are fired after the request is aborted', function(
@@ -596,7 +599,7 @@ describe('pretender invoking', function(config) {
     clock.tick(510);
     assert.equal(
       progressEventCount,
-      4,
+      5,
       'No `onprogress` events are fired after the the request finalizes'
     );
   });


### PR DESCRIPTION
Calculate the size of a FormData request properly by looping over all the fields
and taking either the size (in case of a File object) or length (in case of a string field).
This fixes #303.