### PR TITLE
Fix #321: improve ResponseHandler types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,8 +47,11 @@ export type ResponseHandler = {
   (request: FakeXMLHttpRequest & ExtraRequestData):
     | ResponseData
     | PromiseLike<ResponseData>;
+};
+
+export type ResponseHandlerInstance = ResponseHandler & { 
   async: boolean;
   numberOfCalls: number;
-};
+}
 
 export default Server;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export type RequestHandler = (
   urlExpression: string,
   response: ResponseHandler,
   asyncOrDelay?: boolean | number
-) => void;
+) => ResponseHandlerInstance;
 
 export type ResponseData = [number, { [k: string]: string }, string];
 interface ExtraRequestData {

--- a/src/pretender.ts
+++ b/src/pretender.ts
@@ -1,7 +1,7 @@
 import * as FakeFetch from 'whatwg-fetch';
 import FakeXMLHttpRequest from 'fake-xml-http-request';
 import { Params, QueryParams } from 'route-recognizer';
-import { ResponseHandler } from '../index.d';
+import { ResponseHandler, ResponseHandlerInstance } from '../index.d';
 import Hosts from './hosts';
 import parseURL from './parse-url';
 import Registry from './registry';
@@ -143,7 +143,7 @@ export default class Pretender {
     url: string,
     handler: ResponseHandler,
     async: boolean
-  ): ResponseHandler {
+  ): ResponseHandlerInstance {
     if (!handler) {
       throw new Error(
         'The function you tried passing to Pretender to handle ' +
@@ -154,20 +154,22 @@ export default class Pretender {
       );
     }
 
-    handler.numberOfCalls = 0;
-    handler.async = async;
-    this.handlers.push(handler);
+    const handlerInstance = handler as ResponseHandlerInstance;
+
+    handlerInstance.numberOfCalls = 0;
+    handlerInstance.async = async;
+    this.handlers.push(handlerInstance);
 
     let registry = this.hosts.forURL(url)[verb];
 
     registry.add([
       {
         path: parseURL(url).fullpath,
-        handler: handler,
+        handler: handlerInstance,
       },
     ]);
 
-    return handler;
+    return handlerInstance;
   }
 
   passthrough = PASSTHROUGH;


### PR DESCRIPTION
Fix the ResponseHandler type by introducing a new type that extends
the ResponseHandler and adds the instance-specific attributes to it
(async and numberOfCalls).
This will allow TS clients to use the API as described in the README.