### PR TITLE
normalize `localhost` to `127.0.0.1`

### DIFF
--- a/src/parse-url.ts
+++ b/src/parse-url.ts
@@ -29,13 +29,18 @@ export default function parseURL(url: string) {
     pathname = '/' + pathname; // IE: prepend leading slash
   }
 
-  var host = parsedUrl.host;
-  if (parsedUrl.port === '80' || parsedUrl.port === '443') {
-    host = parsedUrl.hostname; // IE: remove default port
+  var hostname = parsedUrl.hostname;
+  if (hostname === 'localhost') {
+    hostname = '127.0.0.1';
+  }
+  
+  var port = '';
+  if (parsedUrl.port && parsedUrl.port !== '80' && parsedUrl.port !== '443') {
+    port = ':' + parsedUrl.port; // IE: include only non-default ports
   }
 
   return {
-    host: host,
+    host: hostname + port,
     protocol: parsedUrl.protocol,
     search: parsedUrl.query,
     hash: parsedUrl.hash,

--- a/test/url_parsing_test.js
+++ b/test/url_parsing_test.js
@@ -48,7 +48,7 @@ describe('parseURL', function() {
     testUrl('/mock/my/request?test=abc#def', {
       protocol: 'http:',
       pathname: '/mock/my/request',
-      host: window.location.host,
+      host: '127.0.0.1:9876',
       search: '?test=abc',
       hash: '#def',
       fullpath: '/mock/my/request?test=abc#def',
@@ -64,7 +64,7 @@ describe('parseURL', function() {
       {
         protocol: window.location.protocol,
         pathname: '/mock/my/request',
-        host: window.location.host,
+        host: '127.0.0.1:9876',
         search: '?test=abc',
         hash: '#def',
         fullpath: '/mock/my/request?test=abc#def',
@@ -77,6 +77,17 @@ describe('parseURL', function() {
       protocol: 'https:',
       pathname: '/mock/my/request',
       host: 'www.yahoo.com',
+      search: '?test=abc',
+      hash: '',
+      fullpath: '/mock/my/request?test=abc',
+    });
+  });
+  
+  describe('localhost HTTP URLs', function() {
+    testUrl('https://localhost:8080/mock/my/request?test=abc', {
+      protocol: 'https:',
+      pathname: '/mock/my/request',
+      host: '127.0.0.1:8080',
       search: '?test=abc',
       hash: '',
       fullpath: '/mock/my/request?test=abc',


### PR DESCRIPTION
When using pretender, I'll sometimes see or write `localhost` and `127.0.0.1` in the same app. It would be handy if these were normalized to the same value.

Here's a stab at it, but I don't mind if there's a better approach. Feel free to close if this isn't worth the trouble.
