### PR TITLE
Fix - Add default timeout to XMLHttpRequest

### DIFF
--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -90,6 +90,12 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
     xhr.timeout = fakeXHR.timeout;
     xhr.withCredentials = fakeXHR.withCredentials;
   }
+  // XMLHttpRequest.timeout default initializes to 0, and is not allowed to be used for
+  // synchronous XMLHttpRequests requests in a document environment. However, when a XHR
+  // polyfill does not sets the timeout value, it will throw in React Native environment.
+  // TODO:
+  // synchronous XHR is deprecated, make async the default as XMLHttpRequest.open(),
+  // and throw error if sync XHR has timeout not 0
   if (!xhr.timeout) {
     xhr.timeout = 0; // default XMLHttpRequest timeout
   }

--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -90,6 +90,9 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
     xhr.timeout = fakeXHR.timeout;
     xhr.withCredentials = fakeXHR.withCredentials;
   }
+  if (!xhr.timeout) {
+    xhr.timeout = 0; // default XMLHttpRequest timeout
+  }
   for (var h in fakeXHR.requestHeaders) {
     xhr.setRequestHeader(h, fakeXHR.requestHeaders[h]);
   }

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -112,7 +112,7 @@ describe('passthrough requests', function(config) {
     }
   );
 
-  it('synchronous request does not have timeout, withCredentials and onprogress event', function(
+  it('synchronous request has timeout=0, withCredentials and onprogress event', function(
     assert
   ) {
     var pretender = this.pretender;
@@ -125,7 +125,7 @@ describe('passthrough requests', function(config) {
       this.send = {
         pretender: pretender,
         apply: function(xhr/*, argument*/) {
-          assert.ok(!('timeout' in xhr));
+          assert.equal(xhr.timeout, 0);
           assert.ok(!('withCredentials' in xhr));
           assert.ok(!('onprogress' in xhr));
           this.pretender.resolve(xhr);
@@ -139,7 +139,6 @@ describe('passthrough requests', function(config) {
 
     var xhr = new window.XMLHttpRequest();
     xhr.open('POST', '/some/path', false);
-    xhr.timeout = 1000;
     xhr.withCredentials = true;
     xhr.send('some data');
   });


### PR DESCRIPTION
This proposed change is to fix a bug when using Pretender with React Native in Android. If the Pretender request is passthrough and synchronous, Pretender does not assign a timeout to the xhr request variable. When the request is dispatched and reaches native code, it errors out:

```
Attempt to invoke virtual method 'double java.lang.Double.doubleValue()' on a null object reference
```
This is due to the Android native library expecting a numeric `timeout` value. 

[NativeNetworkingAndroid.js Code](https://github.com/facebook/react-native/blob/aa9897830293955b7cc77fd818a50e8d736e715d/Libraries/Network/NativeNetworkingAndroid.js#L25)
```js
  +sendRequest: (
    method: string,
    url: string,
    requestId: number,
    headers: Array<Header>,
    data: Object,
    responseType: string,
    useIncrementalUpdates: boolean,
    timeout: number,
    withCredentials: boolean,
  ) => void;
```
[NetworkingModule.java Code](https://github.com/facebook/react-native/blob/aa9897830293955b7cc77fd818a50e8d736e715d/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java#L238)
```java
@Override
  public void sendRequest(
      String method,
      String url,
      double requestIdAsDouble,
      ReadableArray headers,
      ReadableMap data,
      String responseType,
      boolean useIncrementalUpdates,
      double timeoutAsDouble,
      boolean withCredentials) {
```

To Dos:

- Update tests in `passthrough_test.js` since now we are always adding a timeout, and [this test](https://github.com/pretenderjs/pretender/blob/ddca21671e3e7c69b0be673eb3cd66007931a379/test/passthrough_test.js#L115) will fail.