### PR TITLE
Fix setting timeout to sync XHR

### DIFF
--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -96,7 +96,7 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
   // TODO:
   // synchronous XHR is deprecated, make async the default as XMLHttpRequest.open(),
   // and throw error if sync XHR has timeout not 0
-  if (!xhr.timeout) {
+  if (!xhr.timeout && xhr.timeout !== 0) {
     xhr.timeout = 0; // default XMLHttpRequest timeout
   }
   for (var h in fakeXHR.requestHeaders) {


### PR DESCRIPTION
This happens when creating a sync XHR in a normal window environment, regressed from https://github.com/pretenderjs/pretender/pull/326

Failed to set the 'timeout' property on 'XMLHttpRequest': Timeouts cannot be set for synchronous requests made from a document.