### PR TITLE
Add `yarn build` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ server.shutdown(); // all done.
 
 ## Running tests
 
+* `yarn build` builds pretender so it can be loaded by the tests
 * `yarn test` runs tests once
 * `yarn test:server` runs and reruns on changes
 


### PR DESCRIPTION
On a fresh checkout of the project, the test commands will fail with `ReferenceError: Pretender is not defined` until `yarn build` has been run once to build pretender out to `dist/`. This change documents that requirement in the contribution section of the README.