### PR TITLE
generate index.d.ts in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.7",
   "main": "./dist/pretender.js",
   "module": "./dist/pretender.es.js",
-  "types": "index.d.ts",
+  "types": "./dist/index.d.ts",
   "description": "Pretender is a mock server library for XMLHttpRequest and Fetch, that comes with an express/sinatra style syntax for defining routes and their handlers.",
   "license": "MIT",
   "scripts": {
@@ -42,6 +42,7 @@
     "release-it-lerna-changelog": "^2.3.0",
     "rollup": "^2.10.2",
     "rollup-plugin-typescript": "^1.0.0",
+    "rollup-plugin-typescript2": "^0.30.0",
     "sinon": "^9.0.2",
     "tslib": "^1.9.3",
     "typescript": "~3.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
-import typescript from "rollup-plugin-typescript";
+import typescript from "rollup-plugin-typescript2";
 import { readFileSync } from "fs";
 import pkg from "./package.json";
 
@@ -31,7 +31,7 @@ module.exports = [
         format: "es",
       },
     ],
-    plugins: [commonjs(), resolve(), typescript()],
+    plugins: [commonjs(), resolve(), typescript({ useTsconfigDeclarationDir: true })],
   },
   {
     input: "src/index.ts",
@@ -42,6 +42,6 @@ module.exports = [
         format: "iife",
       }
     ],
-    plugins: [commonjs(), resolve(), typescript()],
+    plugins: [commonjs(), resolve(), typescript({ useTsconfigDeclarationDir: true })],
   },
 ];

--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -3,7 +3,7 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
   var evts = ['error', 'timeout', 'abort', 'readystatechange'];
 
   // event types to handle on the xhr.upload
-  var uploadEvents = [];
+  var uploadEvents: string[] = [];
 
   // properties to copy from the native xhr to fake xhr
   var lifecycleProps = [

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -2,7 +2,7 @@ import FakeXMLHttpRequest from 'fake-xml-http-request';
 import { createPassthrough } from './create-passthrough';
 
 export function interceptor(ctx) {
-  function FakeRequest() {
+  function FakeRequest(this: any) {
     // super()
     FakeXMLHttpRequest.call(this);
   }

--- a/src/pretender.ts
+++ b/src/pretender.ts
@@ -1,7 +1,13 @@
 import * as FakeFetch from 'whatwg-fetch';
 import FakeXMLHttpRequest from 'fake-xml-http-request';
 import { Params, QueryParams } from 'route-recognizer';
-import { ResponseHandler, ResponseHandlerInstance } from '../index.d';
+import {
+  Server as ServerDeprecated,
+  ResponseHandler,
+  ResponseHandlerInstance,
+  ResponseData as _ResponseData,
+  RequestHandler as _RequestHandler,
+} from '../index.d';
 import Hosts from './hosts';
 import parseURL from './parse-url';
 import Registry from './registry';
@@ -16,6 +22,10 @@ interface ExtraRequestData {
 type FakeRequest = FakeXMLHttpRequest & ExtraRequestData;
 
 type Verb = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+export type Server = ServerDeprecated;
+export type ResponseData = _ResponseData;
+export type RequestHandler = _RequestHandler;
 
 class NoopArray {
   length = 0;
@@ -244,7 +254,7 @@ export default class Pretender {
           _handleRequest(result);
         }
       } catch (error) {
-        this.erroredRequest(verb, path, request, error);
+        this.erroredRequest(verb, path, request, error as Error);
         this.resolve(request);
       }
     } else {
@@ -289,7 +299,11 @@ export default class Pretender {
   }
 
   requiresManualResolution(verb: string, path: string) {
-    let handler = this._handlerFor(verb.toUpperCase() as Verb, path, {} as FakeRequest);
+    let handler = this._handlerFor(
+      verb.toUpperCase() as Verb,
+      path,
+      {} as FakeRequest
+    );
     if (!handler) {
       return false;
     }
@@ -297,19 +311,31 @@ export default class Pretender {
     let async = handler.handler.async;
     return typeof async === 'function' ? async() === true : async === true;
   }
-  prepareBody(body, _headers) {
+  prepareBody(body: string, _headers) {
     return body;
   }
-  prepareHeaders(headers) {
+  prepareHeaders(headers: { [k: string]: string }) {
     return headers;
   }
-  handledRequest(_verb, _path, _request) {
+  handledRequest(
+    _verb: string,
+    _path: string,
+    _request: FakeXMLHttpRequest & ExtraRequestData
+  ) {
     /* no-op */
   }
-  passthroughRequest(_verb, _path, _request) {
+  passthroughRequest(
+    _verb: string,
+    _path: string,
+    _request: FakeXMLHttpRequest & ExtraRequestData
+  ) {
     /* no-op */
   }
-  unhandledRequest(verb, path, _request) {
+  unhandledRequest(
+    verb: string,
+    path: string,
+    _request: FakeXMLHttpRequest & ExtraRequestData
+  ) {
     throw new Error(
       'Pretender intercepted ' +
         verb +
@@ -318,7 +344,12 @@ export default class Pretender {
         ' but no handler was defined for this type of request'
     );
   }
-  erroredRequest(verb, path, _request, error) {
+  erroredRequest(
+    verb: string,
+    path: string,
+    _request: FakeXMLHttpRequest & ExtraRequestData,
+    error: Error
+  ) {
     error.message =
       'Pretender intercepted ' +
       verb +

--- a/src/pretender.ts
+++ b/src/pretender.ts
@@ -202,7 +202,7 @@ export default class Pretender {
   }
 
   handleRequest(request: FakeRequest) {
-    let verb = request.method.toUpperCase();
+    let verb = request.method.toUpperCase() as Verb;
     let path = request.url;
 
     let handler = this._handlerFor(verb, path, request);
@@ -289,7 +289,7 @@ export default class Pretender {
   }
 
   requiresManualResolution(verb: string, path: string) {
-    let handler = this._handlerFor(verb.toUpperCase(), path, {});
+    let handler = this._handlerFor(verb.toUpperCase() as Verb, path, {} as FakeRequest);
     if (!handler) {
       return false;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "ESNext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "declaration": false,                     /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "declarationDir": "dist",
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
I was using `miragejs` which builds off of pretender, and noticed that typescript was complaining that `pretender.handledRequests` does not exist. I discovered that pretender uses a separate `index.d.ts` file that is not referenced by the actual class. I've opened issue #337 to report this, but I'm also submitting a PR with my suggested fix.

It is possible to simply add `class Pretender extends Server`, but that would not throw an error if new properties are added to `Pretender` but not to `Server`. In my opinion, the best thing to do is to export the types directly from the source files in the build.

This PR updates the rollup config to include all types in the build, using `rollup-plugin-typescript2`. Doing so also caught a few typescript errors, which I fixed.

I have created a PR on my fork which proves that this change does not affect the generated `.js` files: https://github.com/katehedgpeth/pretender/pull/1