### PR TITLE
Add blob support to passthrough (UPDATED)

### DIFF
--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -25,7 +25,7 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
     fakeXHR.password
   );
 
-  if (fakeXHR.responseType === 'arraybuffer') {
+  if (fakeXHR.responseType === 'arraybuffer' || fakeXHR.responseType === 'blob') {
     lifecycleProps = ['readyState', 'response', 'status', 'statusText'];
     xhr.responseType = fakeXHR.responseType;
   }

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -130,7 +130,6 @@ describe('passthrough requests', function (config) {
           apply: function(xhr, argument) {
             assert.equal(xhr.responseType, 'blob');
             this.pretender.resolve(xhr);
-            QUnit.start();
             done();
           }
         };

--- a/test/passthrough_test.js
+++ b/test/passthrough_test.js
@@ -112,6 +112,40 @@ describe('passthrough requests', function (config) {
     }
   );
 
+  it(
+    'asynchronous request with pass-through and ' +
+      'blob as responseType', 
+    function(assert) {
+      var pretender = this.pretender;
+      var done = assert.async();
+
+      function testXHR() {
+        this.pretender = pretender;
+        this.open = function() {};
+        this.setRequestHeader = function() {};
+        this.upload = {};
+        this.responseType = '';
+        this.send = {
+          pretender: pretender,
+          apply: function(xhr, argument) {
+            assert.equal(xhr.responseType, 'blob');
+            this.pretender.resolve(xhr);
+            QUnit.start();
+            done();
+          }
+        };
+      }
+      pretender._nativeXMLHttpRequest = testXHR;
+
+      pretender.get('/some/path', pretender.passthrough);
+
+      var xhr = new window.XMLHttpRequest();
+      xhr.open('GET', '/some/path');
+      xhr.responseType = 'blob';
+      xhr.send();
+    }
+  );
+
   it('synchronous request has timeout=0, withCredentials and onprogress event', function (assert) {
     var pretender = this.pretender;
     var done = assert.async();


### PR DESCRIPTION
There is still an issue with using `blob` types in passthrough. My company is having to use arraybuffer type as a workaround for this, but native blob support would be much preferred.  

This fix is just an updated version of: https://github.com/pretenderjs/pretender/pull/157 
