### PR TITLE
Add handledRequests, passthroughRequests & unhandledRequests to ts def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,10 @@ export type Config = SetupCallback | SetupConfig;
 export class Server {
   public passthrough: ResponseHandler;
 
+  public handledRequests: (FakeXMLHttpRequest & ExtraRequestData)[];
+  public passthroughRequests: (FakeXMLHttpRequest & ExtraRequestData)[];
+  public unhandledRequests: (FakeXMLHttpRequest & ExtraRequestData)[];
+
   constructor(config?: Config);
   // HTTP request verbs
   public get: RequestHandler;
@@ -49,7 +53,7 @@ export type ResponseHandler = {
     | PromiseLike<ResponseData>;
 };
 
-export type ResponseHandlerInstance = ResponseHandler & { 
+export type ResponseHandlerInstance = ResponseHandler & {
   async: boolean;
   numberOfCalls: number;
 }


### PR DESCRIPTION
Fix https://github.com/pretenderjs/pretender/issues/337

Moving our project to typescript I've bumped into an issue that's been there for a long time apparently: missing handled / unhandled / passthrough request information from the typescript definition.

I can see that the actual value might be an instance of `NoopArray`, but type-wise I think it should be safe to just stick to using an array of requests. Suggestions are welcome. :relaxed: 