### PR TITLE
Check if `window.fetch` exists before polyfilling it

### DIFF
--- a/src/pretender.ts
+++ b/src/pretender.ts
@@ -120,13 +120,15 @@ export default class Pretender {
     (<any>self).XMLHttpRequest = interceptor(ctx);
 
     // polyfill fetch when xhr is ready
-    this._fetchProps = FakeFetch
-      ? ['fetch', 'Headers', 'Request', 'Response']
-      : [];
-    this._fetchProps.forEach((name) => {
-      (<any>this)['_native' + name] = self[name];
-      self[name] = FakeFetch[name];
-    }, this);
+    if (!self.fetch) {
+      this._fetchProps = FakeFetch
+        ? ["fetch", "Headers", "Request", "Response"]
+        : [];
+      this._fetchProps.forEach((name) => {
+        (<any>this)["_native" + name] = self[name];
+        self[name] = FakeFetch[name];
+      }, this);
+    }
 
     // 'start' the server
     this.running = true;


### PR DESCRIPTION
Sorry if this is presumptuous of me, I haven't done much by way of contributing code to OS before, so please let me know if I need to do something before submitting this.

I'm running into an [issue](https://github.com/pretenderjs/pretender/issues/361#issue-1653170925) where `whatwg-fetch` is hijacking the Response object that React Router checks when redirecting. React Router ≥v6.4.5 duck-type checks the Response object, checking specifically if there is a `body` property included. (Since it's [required by W3 Spec](https://fetch.spec.whatwg.org/#concept-response-body)).

I guess `whatwg-fetch` doesn't support the body property, but instead injects a `_bodyInit` property in its place. Something to do with ReadableStreams or whatnot, I'm not sure 😝

That said, I was curious why pretender is using the polyfill in the first place, since my browser is a modern, `fetch`-enabled browser.

Please let me know if there's another, better way I could contribute to this, or help me better understand why a PR like this doesn't make sense. Thanks in advance! 🙏