### PR TITLE
fix: passthrough for binary files

### DIFF
--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -25,7 +25,7 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
     fakeXHR.password
   );
 
-  if (fakeXHR.responseType === 'arraybuffer') {
+  if (fakeXHR.responseType === 'blob' || fakeXHR.responseType === 'arraybuffer') {
     lifecycleProps = ['readyState', 'response', 'status', 'statusText'];
     xhr.responseType = fakeXHR.responseType;
   }
@@ -37,7 +37,7 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
 
   // add progress event for async calls
   // avoid using progress events for sync calls, they will hang https://bugs.webkit.org/show_bug.cgi?id=40996.
-  if (fakeXHR.async && fakeXHR.responseType !== 'arraybuffer') {
+  if (fakeXHR.async) {
     evts.push('progress');
     uploadEvents.push('progress');
   }
@@ -55,26 +55,39 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
   // fire fake event on `eventable`
   function dispatchEvent(eventable, eventType, event) {
     eventable.dispatchEvent(event);
-    if (eventable['on' + eventType]) {
-      eventable['on' + eventType](event);
-    }
   }
 
   // set the on- handler on the native xhr for the given eventType
   function createHandler(eventType) {
-    xhr['on' + eventType] = function (event) {
+    const fakeEventKey = 'on'+eventType;
+
+    if (fakeXHR[fakeEventKey]) {
+      const fn = fakeXHR[fakeEventKey];
+      delete fakeXHR[fakeEventKey];
+      fakeXHR.addEventListener(eventType, fn);
+    }
+
+    xhr.addEventListener(eventType, function (event) {
       copyLifecycleProperties(lifecycleProps, xhr, fakeXHR);
       dispatchEvent(fakeXHR, eventType, event);
-    };
+    });
   }
 
   // set the on- handler on the native xhr's `upload` property for
   // the given eventType
   function createUploadHandler(eventType) {
-    if (xhr.upload && fakeXHR.upload && fakeXHR.upload['on' + eventType]) {
-      xhr.upload['on' + eventType] = function (event) {
+    if (xhr.upload && fakeXHR.upload) {
+      const fakeEventKey = 'on'+eventType;
+
+      if(fakeXHR.upload[fakeEventKey]){
+        const fn = fakeXHR.upload[fakeEventKey];
+        delete fakeXHR.upload[fakeEventKey];
+        fakeXHR.upload.addEventListener(eventType, fn);
+      }
+
+      xhr.upload.addEventListener(eventType, function (event) {
         dispatchEvent(fakeXHR.upload, eventType, event);
-      };
+      });
     }
   }
 

--- a/src/create-passthrough.ts
+++ b/src/create-passthrough.ts
@@ -25,7 +25,10 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
     fakeXHR.password
   );
 
-  if (fakeXHR.responseType === 'blob' || fakeXHR.responseType === 'arraybuffer') {
+  if (
+    fakeXHR.responseType === 'blob' ||
+    fakeXHR.responseType === 'arraybuffer'
+  ) {
     lifecycleProps = ['readyState', 'response', 'status', 'statusText'];
     xhr.responseType = fakeXHR.responseType;
   }
@@ -59,7 +62,7 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
 
   // set the on- handler on the native xhr for the given eventType
   function createHandler(eventType) {
-    const fakeEventKey = 'on'+eventType;
+    const fakeEventKey = 'on' + eventType;
 
     if (fakeXHR[fakeEventKey]) {
       const fn = fakeXHR[fakeEventKey];
@@ -77,9 +80,9 @@ export function createPassthrough(fakeXHR, nativeXMLHttpRequest) {
   // the given eventType
   function createUploadHandler(eventType) {
     if (xhr.upload && fakeXHR.upload) {
-      const fakeEventKey = 'on'+eventType;
+      const fakeEventKey = 'on' + eventType;
 
-      if(fakeXHR.upload[fakeEventKey]){
+      if (fakeXHR.upload[fakeEventKey]) {
         const fn = fakeXHR.upload[fakeEventKey];
         delete fakeXHR.upload[fakeEventKey];
         fakeXHR.upload.addEventListener(eventType, fn);


### PR DESCRIPTION
Fixes https://github.com/pretenderjs/pretender/issues/305
Fixes https://github.com/pretenderjs/pretender/issues/72
Fixes https://github.com/miragejs/ember-cli-mirage/issues/1915

I don't actually fully understand the change being made here, I've just converted the fix from this comment into a PR https://github.com/pretenderjs/pretender/issues/305#issuecomment-685815226
It works great for me. Full credit to @ankology
* I left off the tests from that comment, not sure exactly how to integrate them as tests on this repo

Happy to adjust this PR to update with any suggestions. Would love for it to be merged, but even if it doesn't it at least provides an easier way for people to see the code diff & write their own pnpm patches or point their repos at this branch.

---

Unrelated, but I would implore this fix PR be merged as well https://github.com/pretenderjs/pretender/pull/355
It's another passthrough bug that I've had to write a pnpm patch for in my projects.